### PR TITLE
feat: Add Acontext to Context Engineering list

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 
 - <img src="https://img.shields.io/github/stars/davidkimai/Context-Engineering?style=social" height="17" align="texttop"/> [Context-Engineering](https://github.com/davidkimai/Context-Engineering) - a frontier, first-principles handbook inspired by Karpathy and 3Blue1Brown for moving beyond prompt engineering to the wider discipline of context design, orchestration, and optimization
 - <img src="https://img.shields.io/github/stars/Meirtz/Awesome-Context-Engineering?style=social" height="17" align="texttop"/> [Awesome-Context-Engineering](https://github.com/Meirtz/Awesome-Context-Engineering) - a comprehensive survey on Context Engineering: from prompt engineering to production-grade AI systems
+- <img src="https://img.shields.io/github/stars/memodb-io/Acontext?style=social" height="17" align="texttop"/> [Acontext](https://github.com/memodb-io/Acontext) - a context data platform for building cloud-native AI Agents
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Acontext is a context data platform for building cloud-native AI Agents. It can:

- Store contexts & artifacts.
- Do context engineering for you.
- Observe agent tasks and user feedback.
- Enable agent self-learning by distilling skills from agent's completed tasks.
- View everything in one Dashboard.

Website: https://acontext.io/
Docs: https://docs.acontext.io/

<img width="2560" height="880" alt="Acontext-header-banner" src="https://github.com/user-attachments/assets/ee34f44d-6ecf-4f70-a08d-1069dda19e25" />
