### PR TITLE
Add OpenClaw - Self-hosted AI assistant for edge hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/katanemo/archgw?style=social" height="17" align="texttop"/> [archgw](https://github.com/katanemo/archgw) - a high-performance proxy server that handles the low-level work in building agents: like applying guardrails, routing prompts to the right agent, and unifying access to LLMs, etc.
 - <img src="https://img.shields.io/github/stars/badboysm890/ClaraVerse?style=social" height="17" align="texttop"/> [ClaraVerse](https://github.com/badboysm890/ClaraVerse) - privacy-first, fully local AI workspace with Ollama LLM chat, tool calling, agent builder, Stable Diffusion, and embedded n8n-style automation
 - <img src="https://img.shields.io/github/stars/deepsense-ai/ragbits?style=social" height="17" align="texttop"/> [ragbits](https://github.com/deepsense-ai/ragbits) - building blocks for rapid development of GenAI applications
+- <img src="https://img.shields.io/github/stars/openclaw/openclaw?style=social" height="17" align="texttop"/> [OpenClaw](https://github.com/openclaw/openclaw) - self-hosted AI assistant platform optimized for edge hardware (NVIDIA Jetson). Multi-agent workflows, browser automation, messaging integration (Telegram/WhatsApp/Discord), and cron scheduling. Runs on [dedicated AI hardware](https://local-ai-box.com) at 15W
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
OpenClaw is an open-source AI assistant platform (184K+ stars) optimized for running on edge hardware like NVIDIA Jetson. Features multi-agent workflows, browser automation, and messaging integration.

- Source: https://github.com/openclaw/openclaw
- Hardware: https://local-ai-box.com