### PR TITLE
Add OpenClaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/mudler/LocalAI?style=social" height="17" align="texttop"/> [LocalAI](https://github.com/mudler/LocalAI) -  the free, open-source alternative to OpenAI, Claude and others
 - <img src="https://img.shields.io/github/stars/ChatBoxAI/ChatBox?style=social" height="17" align="texttop"/> [ChatBox](https://github.com/ChatBoxAI/ChatBox) - user-friendly desktop client app for AI models/LLMs
 - <img src="https://img.shields.io/github/stars/lemonade-sdk/lemonade?style=social" height="17" align="texttop"/> [lemonade](https://github.com/lemonade-sdk/lemonade) - a local LLM server with GPU and NPU Acceleration
-- <img src="https://img.shields.io/github/stars/openclaw/openclaw?style=social" height="17" align="texttop"/> [OpenClaw](https://github.com/openclaw/openclaw) - self-hosted AI assistant connecting Claude to WhatsApp, Telegram, Discord, Slack, and more
+- <img src="https://img.shields.io/github/stars/openclaw/openclaw?style=social" height="17" align="texttop"/> [OpenClaw](https://github.com/openclaw/openclaw) - self-hosted AI assistant connecting Claude to WhatsApp, Telegram, Discord, Slack, and more ([docs](https://clawdbot.blog/getting-started/installation/))
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Adding [OpenClaw](https://github.com/openclaw/openclaw) to the Inference platforms section.

OpenClaw is a self-hosted AI assistant platform that connects Claude to multiple messaging channels (WhatsApp, Telegram, Discord, Slack, iMessage, SMS, Email, Signal) from a single local deployment. It runs on macOS, Linux, Windows, and Docker with no cloud dependencies.

- **GitHub**: https://github.com/openclaw/openclaw
- **Documentation**: https://clawdbot.blog/getting-started/installation/
- **License**: MIT
- **Stars**: 190k+
- **Language**: TypeScript