### PR TITLE
Add Off Grid - on-device LLM app for mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/mudler/LocalAI?style=social" height="17" align="texttop"/> [LocalAI](https://github.com/mudler/LocalAI) -  the free, open-source alternative to OpenAI, Claude and others
 - <img src="https://img.shields.io/github/stars/ChatBoxAI/ChatBox?style=social" height="17" align="texttop"/> [ChatBox](https://github.com/ChatBoxAI/ChatBox) - user-friendly desktop client app for AI models/LLMs
 - <img src="https://img.shields.io/github/stars/lemonade-sdk/lemonade?style=social" height="17" align="texttop"/> [lemonade](https://github.com/lemonade-sdk/lemonade) - a local LLM server with GPU and NPU Acceleration
+- <img src="https://img.shields.io/github/stars/alichherawalla/off-grid-mobile?style=social" height="17" align="texttop"/> [Off Grid](https://github.com/alichherawalla/off-grid-mobile) - on-device AI suite for mobile — run LLMs, Stable Diffusion, vision AI, and Whisper entirely on your phone with zero cloud dependency
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
## Add Off Grid to Inference Platforms

[Off Grid](https://github.com/alichherawalla/off-grid-mobile) is an open-source (MIT) mobile app that runs LLMs entirely on-device.

### Supported models
- Qwen 3, Llama 3.2, Gemma 3, Phi-4, and any GGUF model via llama.cpp
- 15-30 tok/s on flagship devices, streaming responses, thinking mode

### Also includes
- On-device Stable Diffusion image generation (NPU-accelerated)
- Vision AI (SmolVLM, Qwen3-VL, Gemma 3n)
- Whisper speech-to-text
- Document analysis (PDF, CSV, code files)

100% offline, privacy-first. Available on [Google Play](https://play.google.com/store/apps/details?id=ai.offgridmobile).