### PR TITLE
Add LazyFish AI Chat to User Interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/oobabooga/text-generation-webui?style=social" height="17" align="texttop"/> [Text generation web UI](https://github.com/oobabooga/text-generation-webui) - LLM UI with advanced features, easy setup, and multiple backend support
 - <img src="https://img.shields.io/github/stars/SillyTavern/SillyTavern?style=social" height="17" align="texttop"/> [SillyTavern](https://github.com/SillyTavern/SillyTavern) - LLM Frontend for Power Users
 - <img src="https://img.shields.io/github/stars/n4ze3m/page-assist?style=social" height="17" align="texttop"/> [Page Assist](https://github.com/n4ze3m/page-assist) - Use your locally running AI models to assist you in your web browsing
+- [LazyFish AI Chat](https://lazyfish.app) - run LLMs entirely in your browser via WebGPU with no API keys, no server, and no data uploads
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Adds [LazyFish AI Chat](https://lazyfish.app) to the User Interfaces section.

LazyFish AI Chat runs LLMs entirely in the browser via WebGPU — no API keys, no server, and no data uploads. Models are downloaded from Hugging Face on first use and cached locally.