### PR TITLE
Add Autohand Code CLI to Coding Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/Kilo-Org/kilocode?style=social" height="17" align="texttop"/> [kilocode](https://github.com/Kilo-Org/kilocode) - open source AI coding assistant for planning, building, and fixing code
 - <img src="https://img.shields.io/github/stars/humanlayer/humanlayer?style=social" height="17" align="texttop"/> [humanlayer](https://github.com/humanlayer/humanlayer) - the best way to get AI coding agents to solve hard problems in complex codebases
 - <img src="https://img.shields.io/github/stars/carlrobertoh/ProxyAI?style=social" height="17" align="texttop"/> [ProxyAI](https://github.com/carlrobertoh/ProxyAI) - the leading open-source AI copilot for JetBrains
+- <img src="https://img.shields.io/github/stars/autohandai/code-cli?style=social" height="17" align="texttop"/> [Autohand Code CLI](https://github.com/autohandai/code-cli) - a self-evolving autonomous coding agent for the terminal with native Ollama and local model support, multi-provider LLM integration, and 40+ built-in tools
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Submitting Autohand Code CLI for the Coding Agents section. It's a terminal-based autonomous coding agent that's particularly relevant to this list because of its first-class local model support:

- Works natively with **Ollama** and other local model runtimes — no cloud API required
- Also supports OpenRouter, Anthropic, and OpenAI for hybrid setups
- Uses a ReAct reasoning pattern with 40+ built-in tools
- Integrates with VS Code and Zed editors
- Apache 2.0 licensed

For developers who want full privacy and local-first AI coding assistance, it fits right in with the local LLM philosophy of this list.

Repo: https://github.com/autohandai/code-cli