### PR TITLE
Add LLMKube to inference platforms section

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/mudler/LocalAI?style=social" height="17" align="texttop"/> [LocalAI](https://github.com/mudler/LocalAI) -  the free, open-source alternative to OpenAI, Claude and others
 - <img src="https://img.shields.io/github/stars/ChatBoxAI/ChatBox?style=social" height="17" align="texttop"/> [ChatBox](https://github.com/ChatBoxAI/ChatBox) - user-friendly desktop client app for AI models/LLMs
 - <img src="https://img.shields.io/github/stars/lemonade-sdk/lemonade?style=social" height="17" align="texttop"/> [lemonade](https://github.com/lemonade-sdk/lemonade) - a local LLM server with GPU and NPU Acceleration
+- <img src="https://img.shields.io/github/stars/defilantech/LLMKube?style=social" height="17" align="texttop"/> [LLMKube](https://github.com/defilantech/LLMKube) - Kubernetes operator for llama.cpp-native LLM inference with NVIDIA CUDA and Apple Silicon Metal GPU support
 
 [Back to Table of Contents](#table-of-contents)
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/mudler/LocalAI?style=social" height="17" align="texttop"/> [LocalAI](https://github.com/mudler/LocalAI) -  the free, open-source alternative to OpenAI, Claude and others
 - <img src="https://img.shields.io/github/stars/ChatBoxAI/ChatBox?style=social" height="17" align="texttop"/> [ChatBox](https://github.com/ChatBoxAI/ChatBox) - user-friendly desktop client app for AI models/LLMs
 - <img src="https://img.shields.io/github/stars/lemonade-sdk/lemonade?style=social" height="17" align="texttop"/> [lemonade](https://github.com/lemonade-sdk/lemonade) - a local LLM server with GPU and NPU Acceleration
-- <img src="https://img.shields.io/github/stars/defilantech/LLMKube?style=social" height="17" align="texttop"/> [LLMKube](https://github.com/defilantech/LLMKube) - Kubernetes operator for llama.cpp-native LLM inference with NVIDIA CUDA and Apple Silicon Metal GPU support
+- <img src="https://img.shields.io/github/stars/defilantech/LLMKube?style=social" height="17" align="texttop"/> [LLMKube](https://github.com/defilantech/LLMKube) - Kubernetes operator for LLM inference with pluggable runtimes (llama.cpp, PersonaPlex/Moshi, generic), multi-GPU sharding, NVIDIA CUDA and Apple Silicon Metal support, and GGUF/MLX/SafeTensors model formats
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Adding [LLMKube](https://github.com/defilantech/LLMKube) to the Inference engines section.

LLMKube is an open-source Kubernetes operator for LLM inference with:
- Pluggable runtime backends (llama.cpp, PersonaPlex/Moshi, generic)
- Multi-GPU layer sharding
- NVIDIA CUDA and Apple Silicon Metal GPU support
- GGUF, MLX, SafeTensors, and PyTorch model formats
- CRD-based model and inference service management
- Prometheus metrics and OpenAI-compatible API
- Helm chart and HPA autoscaling
- Apache 2.0 license

I'm the creator and maintainer.