### PR TITLE
Add GPU Ark VRAM Calculator to Hardware section

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/youtube/channel/subscribers/UC8h2Sf-yyo1WXeEUr-OHgyg?style=social" height="17" align="texttop"/> [Miyconst](https://www.youtube.com/@Miyconst) - tests of various types of hardware capable of running LLMs
 - [Kolosal - LLM Memory calculator](https://www.kolosal.ai/memory-calculator) - estimate the RAM requirements of any GGUF model instantly
 - [LLM Inference VRAM & GPU Requirement Calculator](https://app.linpp2009.com/en/llm-gpu-memory-calculator) - calculate how many GPUs you need to deploy LLMs
+- [GPU Ark - VRAM Calculator](https://gpuark.com/en/vram-calculator/) - estimate VRAM requirements for any LLM by parameter count and quantization, with a GPU specs database and performance index
 - <img src="https://img.shields.io/github/stars/vosen/ZLUDA?style=social" height="17" align="texttop"/> [ZLUDA](https://github.com/vosen/ZLUDA) - CUDA on non-NVIDIA GPUs
 - [Strix Halo Wiki](https://strixhalo.wiki/) - a website to gather important information and practical guides for systems powered by AMD Ryzen AI MAX and MAX+ processors
 


### PR DESCRIPTION
Added [GPU Ark - VRAM Calculator](https://gpuark.com/en/vram-calculator/) to the Hardware section.

It estimates VRAM requirements for any LLM by parameter count and quantization level (FP16, Q8, Q4, etc.), and includes a comprehensive GPU specs database with a performance index for comparing GPUs side-by-side.

Fits alongside the existing Kolosal and LLM Inference calculators already in the section.