### PR TITLE
Add TITAN to Agent Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/katanemo/archgw?style=social" height="17" align="texttop"/> [archgw](https://github.com/katanemo/archgw) - a high-performance proxy server that handles the low-level work in building agents: like applying guardrails, routing prompts to the right agent, and unifying access to LLMs, etc.
 - <img src="https://img.shields.io/github/stars/badboysm890/ClaraVerse?style=social" height="17" align="texttop"/> [ClaraVerse](https://github.com/badboysm890/ClaraVerse) - privacy-first, fully local AI workspace with Ollama LLM chat, tool calling, agent builder, Stable Diffusion, and embedded n8n-style automation
 - <img src="https://img.shields.io/github/stars/deepsense-ai/ragbits?style=social" height="17" align="texttop"/> [ragbits](https://github.com/deepsense-ai/ragbits) - building blocks for rapid development of GenAI applications
+- <img src="https://img.shields.io/github/stars/Djtony707/TITAN?style=social" height="17" align="texttop"/> [TITAN](https://github.com/Djtony707/TITAN) - autonomous AI agent framework with 149 tools, 34 LLM providers, P2P mesh networking, WebRTC voice, RAG, MCP server mode, and React dashboard
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
## Summary

Adding [TITAN](https://github.com/Djtony707/TITAN) to the Agent Frameworks section.

TITAN is an open-source autonomous AI agent framework built with TypeScript/Node.js. It supports 34 LLM providers (including Ollama and other local providers), 149 built-in tools, P2P mesh networking, WebRTC voice via LiveKit, RAG with vector search, MCP server mode, sandbox code execution, and a React dashboard. MIT licensed with 3,879 tests.

- **GitHub**: https://github.com/Djtony707/TITAN
- **npm**: https://www.npmjs.com/package/titan-agent
- **License**: MIT

It fits well in the Agent Frameworks section as a self-hosted, locally-runnable agent framework that works with local LLM providers like Ollama.