### PR TITLE
Add TrashClaw to Agent Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/katanemo/archgw?style=social" height="17" align="texttop"/> [archgw](https://github.com/katanemo/archgw) - a high-performance proxy server that handles the low-level work in building agents: like applying guardrails, routing prompts to the right agent, and unifying access to LLMs, etc.
 - <img src="https://img.shields.io/github/stars/badboysm890/ClaraVerse?style=social" height="17" align="texttop"/> [ClaraVerse](https://github.com/badboysm890/ClaraVerse) - privacy-first, fully local AI workspace with Ollama LLM chat, tool calling, agent builder, Stable Diffusion, and embedded n8n-style automation
 - <img src="https://img.shields.io/github/stars/deepsense-ai/ragbits?style=social" height="17" align="texttop"/> [ragbits](https://github.com/deepsense-ai/ragbits) - building blocks for rapid development of GenAI applications
+- <img src="https://img.shields.io/github/stars/Scottcjn/trashclaw?style=social" height="17" align="texttop"/> [TrashClaw](https://github.com/Scottcjn/trashclaw) - local LLM tool-use agent with zero dependencies, supports llama.cpp, Ollama, and LM Studio, runs on anything from a 2013 Mac Pro to modern hardware
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
## TrashClaw

- **GitHub**: https://github.com/Scottcjn/trashclaw
- **License**: MIT

Local LLM tool-use agent with zero external dependencies. Pure Python, supports llama.cpp, Ollama, and LM Studio backends. Built and tested on a 2013 Mac Pro trashcan with dual AMD FirePro D500s. Runs on vintage and modern hardware alike.

Added to the Agent Frameworks section, following existing entry format with star badge.