### PR TITLE
feat: add free-web-search-ultimate tool for local LLMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 
 ## Tools
 
+- <img src="https://img.shields.io/github/stars/wd041216-bit/free-web-search-ultimate?style=social" height="17" align="texttop"/> [free-web-search-ultimate](https://github.com/wd041216-bit/free-web-search-ultimate) [![free-web-search-ultimate MCP server](https://glama.ai/mcp/servers/wd041216-bit/free-web-search-ultimate/badges/score.svg)](https://glama.ai/mcp/servers/wd041216-bit/free-web-search-ultimate) - Zero-cost MCP server and CLI tool for real-time web search. Enforces **Search-First** paradigm for local LLMs. Supports DuckDuckGo, Bing, Google, Brave, Wikipedia, Arxiv, YouTube, Reddit. No API key required. Install: `pip install free-web-search-ultimate`
 ### Models
 
 - <img src="https://img.shields.io/github/stars/unslothai/unsloth?style=social" height="17" align="texttop"/> [unsloth](https://github.com/unslothai/unsloth) - fine-tuning & reinforcement learning for LLMs


### PR DESCRIPTION
## Add free-web-search-ultimate: MCP server + CLI tool for local LLMs

Adding [free-web-search-ultimate](https://github.com/wd041216-bit/free-web-search-ultimate) to the Tools section.

This MCP server + CLI tool enables local LLMs to perform real-time web searches without any API key, making it perfect for privacy-focused local AI setups.

**Key features:**
- Zero-cost, no API key required
- - Privacy-first (DuckDuckGo by default)
- - MCP server for Claude Desktop, Cursor, Open WebUI, etc.
- - CLI tool: `free-web-search`
- - Supports 10+ search engines (DuckDuckGo, Bing, Google, Brave, Wikipedia, Arxiv, YouTube, Reddit)
- - Enforces **Search-First** paradigm — instructs local LLMs to retrieve real-time info before answering
- - Glama AAA rated [![Glama](https://glama.ai/mcp/servers/wd041216-bit/free-web-search-ultimate/badges/score.svg)](https://glama.ai/mcp/servers/wd041216-bit/free-web-search-ultimate)
Install: `pip install free-web-search-ultimate`