### PR TITLE
Add Self-Hosted AI Workflow Pack to Agent Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/katanemo/archgw?style=social" height="17" align="texttop"/> [archgw](https://github.com/katanemo/archgw) - a high-performance proxy server that handles the low-level work in building agents: like applying guardrails, routing prompts to the right agent, and unifying access to LLMs, etc.
 - <img src="https://img.shields.io/github/stars/badboysm890/ClaraVerse?style=social" height="17" align="texttop"/> [ClaraVerse](https://github.com/badboysm890/ClaraVerse) - privacy-first, fully local AI workspace with Ollama LLM chat, tool calling, agent builder, Stable Diffusion, and embedded n8n-style automation
 - <img src="https://img.shields.io/github/stars/deepsense-ai/ragbits?style=social" height="17" align="texttop"/> [ragbits](https://github.com/deepsense-ai/ragbits) - building blocks for rapid development of GenAI applications
+- [Self-Hosted AI Workflow Pack](https://bonskari.github.io/n8n-ai-workflows/) - 11 production-ready n8n workflow templates powered by Ollama for local AI automation, no API keys needed
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
## Summary
- Adds [Self-Hosted AI Workflow Pack](https://bonskari.github.io/n8n-ai-workflows/) to the Agent Frameworks section
- 11 production-ready n8n workflow templates powered by Ollama for fully local AI automation
- No API keys or cloud dependencies needed — runs entirely on local infrastructure

## Why this belongs here
This resource is directly relevant to the local LLM ecosystem — it provides ready-to-use workflow templates that connect n8n with Ollama, enabling users to build AI-powered automations using their own local models.