### PR TITLE
Add asiai — Apple Silicon multi-engine LLM benchmark CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/badge/NVIDIA-%25?logo=nvidia&labelColor=white" height="17" align="texttop"/> <img src="https://img.shields.io/github/stars/NVIDIA/garak?style=social" height="17" align="texttop"/> [garak](https://github.com/NVIDIA/garak) - the LLM vulnerability scanner from NVIDIA
 - <img src="https://img.shields.io/github/stars/Giskard-AI/giskard?style=social" height="17" align="texttop"/> [giskard](https://github.com/Giskard-AI/giskard) - an open-source evaluation & testing for AI & LLM systems
 - <img src="https://img.shields.io/github/stars/Agenta-AI/agenta?style=social" height="17" align="texttop"/> [agenta](https://github.com/Agenta-AI/agenta) - an open-source LLMOps platform: prompt playground, prompt management, LLM evaluation, and LLM observability all in one place
+- <img src="https://img.shields.io/github/stars/druide67/asiai?style=social" height="17" align="texttop"/> [asiai](https://github.com/druide67/asiai) - a multi-engine LLM benchmark & monitoring CLI for Apple Silicon. Compare 7 inference engines (Ollama, LM Studio, llama.cpp, mlx-lm, oMLX, vLLM-MLX, Exo) side by side with tok/s, TTFT, power efficiency, VRAM, and shareable benchmark cards
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
## What is asiai?

[asiai](https://github.com/druide67/asiai) is an open-source CLI tool that benchmarks and monitors LLM inference engines on Apple Silicon.

**Key features:**
- Compare 7 engines side by side (Ollama, LM Studio, llama.cpp, mlx-lm, oMLX, vLLM-MLX, Exo)
- Metrics: tok/s, TTFT, power efficiency (tok/s/W), VRAM, stability
- Web dashboard with live monitoring
- Shareable benchmark cards
- MCP server for AI agent integration
- 1K+ monthly PyPI downloads

**Links:** [GitHub](https://github.com/druide67/asiai) · [PyPI](https://pypi.org/project/asiai/) · [Docs](https://asiai.dev)

**Placement:** Added to "Testing, Evaluation and Observability" section, as asiai focuses on benchmarking and monitoring inference performance.