### PR TITLE
Add AI Computer Guide to Hardware section

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - [LLM Inference VRAM & GPU Requirement Calculator](https://app.linpp2009.com/en/llm-gpu-memory-calculator) - calculate how many GPUs you need to deploy LLMs
 - <img src="https://img.shields.io/github/stars/vosen/ZLUDA?style=social" height="17" align="texttop"/> [ZLUDA](https://github.com/vosen/ZLUDA) - CUDA on non-NVIDIA GPUs
 - [Strix Halo Wiki](https://strixhalo.wiki/) - a website to gather important information and practical guides for systems powered by AMD Ryzen AI MAX and MAX+ processors
+- [AI Computer Guide](https://aicomputerguide.com/) - GPU compatibility checker, VRAM requirements, and curated PC builds for running local LLMs
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
AI Computer Guide (https://aicomputerguide.com/) is a resource for people running local LLMs that includes:
- A GPU compatibility checker (Will It Run?)
- VRAM requirement guides for popular models (Llama 3, Mistral, DeepSeek R1)
- Curated PC builds optimized for local inference at different budget tiers

Fits well alongside the other hardware/calculator tools in the Hardware section.