### PR TITLE
Add SwarmClaw and SwarmVault

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/katanemo/archgw?style=social" height="17" align="texttop"/> [archgw](https://github.com/katanemo/archgw) - a high-performance proxy server that handles the low-level work in building agents: like applying guardrails, routing prompts to the right agent, and unifying access to LLMs, etc.
 - <img src="https://img.shields.io/github/stars/badboysm890/ClaraVerse?style=social" height="17" align="texttop"/> [ClaraVerse](https://github.com/badboysm890/ClaraVerse) - privacy-first, fully local AI workspace with Ollama LLM chat, tool calling, agent builder, Stable Diffusion, and embedded n8n-style automation
 - <img src="https://img.shields.io/github/stars/deepsense-ai/ragbits?style=social" height="17" align="texttop"/> [ragbits](https://github.com/deepsense-ai/ragbits) - building blocks for rapid development of GenAI applications
+- <img src="https://img.shields.io/github/stars/swarmclawai/swarmclaw?style=social" height="17" align="texttop"/> [SwarmClaw](https://github.com/swarmclawai/swarmclaw) - self-hosted multi-agent AI runtime with MCP client + server, persistent memory, skills, schedules, and 23+ providers including Ollama and any OpenAI-compatible endpoint
 
 [Back to Table of Contents](#table-of-contents)
 
@@ -288,6 +289,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/onyx-dot-app/onyx?style=social" height="17" align="texttop"/> [onyx](https://github.com/onyx-dot-app/onyx) - the AI platform connected to your company's docs, apps, and people
 - <img src="https://img.shields.io/github/stars/zilliztech/claude-context?style=social" height="17" align="texttop"/> [claude-context](https://github.com/zilliztech/claude-context) - make entire codebase the context for any coding agent
 - <img src="https://img.shields.io/github/stars/pipeshub-ai/pipeshub-ai?style=social" height="17" align="texttop"/> [pipeshub-ai](https://github.com/pipeshub-ai/pipeshub-ai) - a fully extensible and explainable workplace AI platform for enterprise search and workflow automation
+- <img src="https://img.shields.io/github/stars/swarmclawai/swarmvault?style=social" height="17" align="texttop"/> [SwarmVault](https://github.com/swarmclawai/swarmvault) - local-first RAG knowledge base compiler with persistent markdown wiki, knowledge graph, hybrid SQLite FTS + embeddings, and offline heuristic + Ollama embedders
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Adding SwarmClaw to the Agent Frameworks section and SwarmVault to the Retrieval-Augmented Generation section.

Both are designed for local-first, self-hosted use — SwarmClaw supports Ollama and any OpenAI-compatible endpoint natively, and SwarmVault ships with an offline heuristic embedder plus Ollama support, so both fit this list's focus on local LLM deployment.

- SwarmClaw: https://github.com/swarmclawai/swarmclaw
- SwarmVault: https://github.com/swarmclawai/swarmvault

License: MIT