### PR TITLE
Add llama-dash

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/badge/NVIDIA-%25?logo=nvidia&labelColor=white" height="17" align="texttop"/> <img src="https://img.shields.io/github/stars/NVIDIA/garak?style=social" height="17" align="texttop"/> [garak](https://github.com/NVIDIA/garak) - the LLM vulnerability scanner from NVIDIA
 - <img src="https://img.shields.io/github/stars/Giskard-AI/giskard?style=social" height="17" align="texttop"/> [giskard](https://github.com/Giskard-AI/giskard) - an open-source evaluation & testing for AI & LLM systems
 - <img src="https://img.shields.io/github/stars/Agenta-AI/agenta?style=social" height="17" align="texttop"/> [agenta](https://github.com/Agenta-AI/agenta) - an open-source LLMOps platform: prompt playground, prompt management, LLM evaluation, and LLM observability all in one place
+- <img src="https://img.shields.io/github/stars/ndom91/llama-dash?style=social" height="17" align="texttop"/> [llama-dash](https://github.com/ndom91/llama-dash) - local LLM operator dashboard and proxy
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Adds https://github.com/ndom91/llama-dash in the "Testing, Evaluation and Observability" category.

- Alternative UI + proxy on top of [llama-swap](https://github.com/mostlygeek/llama-swap) for monitoring local LLMs
- Transparent `/v1/*` proxy supporting both OpenAI and Anthropic shapes (including Claude Code via `ANTHROPIC_BASE_URL`), with per-request logging, token scraping, and SSE streaming preserved
- Dashboard with live stats, GPU monitoring (NVIDIA/AMD/Apple Silicon), model load/unload timeline, and an in-browser config.yaml editor with schema validation
- API key management with per-key RPM/TPM limits, model allow-lists, system prompt injection, and usage attribution via configurable headers
- Built-in playground (chat/image/speech/transcribe) with llama.cpp timing metadata, plus ordered routing policies for model rewrites
- TypeScript/TanStack Start + Drizzle/SQLite, shipped as Docker Compose setups for ROCm and CUDA
