### PR TITLE
Add EnigmAgent - encrypted local AI credential vault with MCP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 
 ### Security and Sandboxing
 
+- [EnigmAgent](https://github.com/Agnuxo1/EnigmAgent) - Encrypted local vault for AI agent credentials. Browser extension + MCP server (`enigmagent-mcp`) using AES-256-GCM + Argon2id. Agents use {{PLACEHOLDER}} references; secrets never leave the device.
 - <img src="https://img.shields.io/badge/NVIDIA-%25?logo=nvidia&labelColor=white" height="17" align="texttop"/> <img src="https://img.shields.io/github/stars/NVIDIA-NeMo/Guardrails?style=social" height="17" align="texttop"/> [Guardrails](https://github.com/NVIDIA-NeMo/Guardrails) - an open-source toolkit from NVIDIA for easily adding programmable guardrails to LLM-based conversational systems
 - <img src="https://img.shields.io/badge/NVIDIA-%25?logo=nvidia&labelColor=white" height="17" align="texttop"/> <img src="https://img.shields.io/github/stars/NVIDIA/OpenShell?style=social" height="17" align="texttop"/> [OpenShell](https://github.com/NVIDIA/OpenShell) - the safe, private runtime for autonomous AI agents from NVIDIA
 - <img src="https://img.shields.io/github/stars/TencentCloud/CubeSandbox?style=social" height="17" align="texttop"/> [CubeSandbox](https://github.com/TencentCloud/CubeSandbox) - instant, concurrent, secure & lightweight sandbox for AI agents


### PR DESCRIPTION
EnigmAgent provides encrypted local credential storage for AI agents. Agents use `{{PLACEHOLDER}}` references instead of real secrets. The MCP server (`enigmagent-mcp`) enables any MCP-compatible AI to resolve secrets from the encrypted vault. AES-256-GCM + Argon2id. https://github.com/Agnuxo1/EnigmAgent