### PR TITLE
Add vimin-core — distributed local LLM/Whisper orchestration across multiple machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/brontoguana/krasis?style=social" height="17" align="texttop"/> [krasis](https://github.com/brontoguana/krasis) - a Hybrid LLM runtime which focuses on efficient running of larger models on consumer grade VRAM limited hardware
 - <img src="https://img.shields.io/github/stars/nlzy/vllm-gfx906?style=social" height="17" align="texttop"/> [vllm-gfx906](https://github.com/nlzy/vllm-gfx906) - vLLM for AMD gfx906 GPUs, e.g. Radeon VII / MI50 / MI60
 - <img src="https://img.shields.io/github/stars/intel/llm-scaler?style=social" height="17" align="texttop"/> [llm-scaler](https://github.com/intel/llm-scaler) - run LLMs on Intel Arc™ Pro B60 GPUs
+- <img src="https://img.shields.io/github/stars/pberlizov/vimin-public?style=social" height="17" align="texttop"/> [vimin-core](https://github.com/pberlizov/vimin-public) - orchestrate distributed local LLM and Whisper inference across up to 10 machines; MLX on Apple Silicon, llama.cpp elsewhere; air-gapped and privacy-first; MIT
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
## What is vimin-core?

[vimin-core](https://github.com/pberlizov/vimin-public) is a Python library for orchestrating distributed local LLM and Whisper inference across a fleet of up to 10 machines — with no cloud dependency, no telemetry, and no vendor lock-in.

**Key features:**
- **Broadcast**: send a prompt to all connected agents simultaneously, collect every response
- **Pipelines**: multi-step workflows where each step uses a different task type (translate → redact PII → summarize, etc.)
- **MLX** on Apple Silicon, **llama.cpp** on any platform, **mlx-whisper / faster-whisper** for speech
- Designed for **air-gapped networks**, healthcare, legal, and enterprise environments where data cannot leave the machine
- MIT license

**Install:**
```bash
pip install 'vimin-core[mlx]'      # Apple Silicon
pip install 'vimin-core[llamacpp]' # Any platform
```

Fits naturally in the **Inference engines** section alongside `exo` and `distributed-llama` as a distributed/fleet inference tool.