### PR TITLE
Add Off Grid (mobile on-device LLM app) to Inference platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 ## Inference platforms
 
 - [LM Studio](https://lmstudio.ai/) - discover, download and run local LLMs
+- <img src="https://img.shields.io/github/stars/alichherawalla/off-grid-mobile-ai?style=social" height="17" align="texttop"/> [Off Grid](https://github.com/alichherawalla/off-grid-mobile-ai) - open-source iOS/Android/Mac app running LLMs entirely on-device via llama.cpp; voice (Whisper), vision, image gen, tool calling — fully offline, MIT
 - <img src="https://img.shields.io/github/stars/unslothai/unsloth?style=social" height="17" align="texttop"/> [unsloth](https://github.com/unslothai/unsloth) -  unified web UI for training and running open models like Qwen, DeepSeek, and Gemma locally
 - <img src="https://img.shields.io/github/stars/mudler/LocalAI?style=social" height="17" align="texttop"/> [LocalAI](https://github.com/mudler/LocalAI) -  the free, open-source alternative to OpenAI, Claude and others
 - <img src="https://img.shields.io/github/stars/menloresearch/jan?style=social" height="17" align="texttop"/> [jan](https://github.com/menloresearch/jan) - an open source alternative to ChatGPT that runs 100% offline on your computer


### PR DESCRIPTION
Adds [Off Grid](https://github.com/alichherawalla/off-grid-mobile-ai) to the **Inference platforms** section.

Off Grid is the mobile-native member that section currently lacks — neighbors (LM Studio, Jan, ChatBox) are all desktop/server-side.

- Open-source iOS / Android / Apple Silicon Mac, MIT-licensed (1,785 stars)
- Runs LLMs entirely on-device via llama.cpp + GGUF
- Supports Llama 3.2, Qwen 3, Gemma 3, Phi-4, DeepSeek R1, Mistral
- Voice (whisper.cpp), vision, on-device image generation (Stable Diffusion + NPU on Snapdragon), tool calling, project knowledge bases with on-device embeddings
- 100% offline, no account, no telemetry. Airplane-mode tested.
- 10K+ Android installs (4.0★), 4.3★ App Store

Inserted alphabetically between LM Studio and unsloth, matching the existing badge format used for GitHub-hosted projects.