### PR TITLE
feat: add KubeStellar Console kc-agent MCP server for Kubernetes management

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/awslabs/mcp?style=social" height="17" align="texttop"/> [awslabs/mcp](https://github.com/awslabs/mcp) - AWS MCP Servers — helping you get the most out of AWS, wherever you use MCP
 - <img src="https://img.shields.io/github/stars/sooperset/mcp-atlassian?style=social" height="17" align="texttop"/> [mcp-atlassian](https://github.com/sooperset/mcp-atlassian) - MCP server for Atlassian tools (Confluence, Jira)
 - <img src="https://img.shields.io/github/stars/bytebase/dbhub?style=social" height="17" align="texttop"/> [dbhub](https://github.com/bytebase/dbhub) - zero-dependency, token-efficient database MCP server for Postgres, MySQL, SQL Server, MariaDB, SQLite
+- <img src="https://img.shields.io/github/stars/kubestellar/console?style=social" height="17" align="texttop"/> [kubestellar-console kc-agent](https://github.com/kubestellar/console) - MCP server for Kubernetes management — lets AI agents inspect pods, deployments, namespaces, RBAC, GPU workloads, and cluster health across multi-cluster environments
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
## Add KubeStellar Console kc-agent to Model Context Protocol section

Adding [KubeStellar Console kc-agent](https://github.com/kubestellar/console) to the **Model Context Protocol** section.

**KubeStellar Console kc-agent** is a local MCP server that bridges AI agents to Kubernetes clusters via the kubeconfig. It enables AI agents (Claude Code, Cursor, GitHub Copilot, Codex, etc.) to:

- **Inspect cluster resources**: pods, deployments, namespaces, services, ConfigMaps across multiple clusters
- **Monitor workload health**: real-time status, events, logs, and resource metrics
- **Manage RBAC**: roles, bindings, and access policies via natural language
- **GPU workload visibility**: track GPU allocation and utilization across federated clusters
- **Multi-cluster orchestration**: manage resources across multiple Kubernetes contexts simultaneously
- **Diagnose issues**: correlate logs, events, and metrics for AI-assisted root cause analysis

It's the Kubernetes equivalent of the GitHub MCP server — letting AI coding agents not just write code but also understand, diagnose, and manage the infrastructure it runs on.

**GitHub**: https://github.com/kubestellar/console
**License**: Apache 2.0
**Stars**: 80+
