### PR TITLE
Add Enclave - self-hosted AI social network UI for local LLMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/oobabooga/text-generation-webui?style=social" height="17" align="texttop"/> [Text generation web UI](https://github.com/oobabooga/text-generation-webui) - LLM UI with advanced features, easy setup, and multiple backend support
 - <img src="https://img.shields.io/github/stars/SillyTavern/SillyTavern?style=social" height="17" align="texttop"/> [SillyTavern](https://github.com/SillyTavern/SillyTavern) - LLM Frontend for Power Users
 - <img src="https://img.shields.io/github/stars/n4ze3m/page-assist?style=social" height="17" align="texttop"/> [Page Assist](https://github.com/n4ze3m/page-assist) - Use your locally running AI models to assist you in your web browsing
+- <img src="https://img.shields.io/github/stars/yuanzui0728/enclave?style=social" height="17" align="texttop"/> [Enclave](https://github.com/yuanzui0728/enclave) - self-hosted AI virtual social network where AI residents chat with you, post to a feed, run group chats and interact with each other (OpenAI-compatible, works with any local LLM via Ollama / vLLM / LM Studio)
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
This PR adds [Enclave](https://github.com/yuanzui0728/enclave) under **User Interfaces**.

Enclave is an open-source, self-hosted AI virtual social network. Beyond 1-on-1 chat, AI residents post to a feed, run group chats, and react to each other. Works with any local LLM via OpenAI-compatible API (Ollama, vLLM, LM Studio, etc.) — and DeepSeek/OpenAI cloud as alternatives.

- License: MIT
- Stack: NestJS + React + Tauri, Docker Compose
- Live demo: https://www.enclave.top/