### PR TITLE
Add Local LLM Matcher – Free GPU-LLM compatibility tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - [SWE-rebench](https://swe-rebench.com/) - a continuously evolving and decontaminated benchmark for software engineering LLMs
 - <img src="https://img.shields.io/github/stars/petergpt/bullshit-benchmark?style=social" height="17" align="texttop"/> [BullshitBench](https://github.com/petergpt/bullshit-benchmark) - measure whether AI models challenge nonsensical prompts instead of confidently answering them
 - [LLM Explorer](https://llm-explorer.com/) - explore list of the open-source LLM models
+- [Local LLM Matcher](https://locallmmatcher.com) - free browser-based tool that auto-detects your device specs (RAM, OS, GPU VRAM) and recommends compatible open-source LLMs for local deployment; supports 13+ model families including Llama, DeepSeek, Qwen, Mistral, Gemma, Phi-4; includes Ollama setup guides and GPU compatibility tables
 - [Dubesor LLM Benchmark table](https://dubesor.de/benchtable) - small-scale manual performance comparison benchmark
 - [oobabooga benchmark](https://oobabooga.github.io/benchmark.html) - a list sorted by size (on disk) for each score
 - [CyberGym](https://www.cybergym.io/) - evaluating AI agents' real-world cybersecurity capabilities at scale


### PR DESCRIPTION
Hi, I'd like to suggest adding **Local LLM Matcher** to this awesome list.

**Website**: https://locallmmatcher.com

**What it does**: A free browser-based tool that auto-detects your device specs (RAM, OS, GPU VRAM) and recommends compatible open-source LLMs for local deployment. Supports 13+ model families including Llama, DeepSeek, Qwen, Mistral, Gemma, Phi-4, and more. Includes Ollama setup guides and GPU compatibility tables.

**Why it fits this list**: It helps developers and AI enthusiasts quickly find which local LLMs they can run based on their hardware constraints — directly relevant to the local LLM / AI tools community.

**Key features**:
- Auto-detects system RAM, OS, and browser
- Manual GPU VRAM selector (8GB to 80GB+)
- Matches 60+ parameter versions across 13 model families
- Step-by-step deployment guides for each recommended model
- No signup required, completely free

I've added it to the **Explorers, Benchmarks, Leaderboards** section as it helps users discover which LLMs are compatible with their hardware — similar in spirit to LLM Explorer.

Thanks for maintaining this great resource!