### PR TITLE
Add dakera-mcp to Memory Management section

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/LMCache/LMCache?style=social" height="17" align="texttop"/> [LMCache](https://github.com/LMCache/LMCache) - supercharge your LLM with the fastest KV Cache Layer
 - <img src="https://img.shields.io/github/stars/NevaMind-AI/memU?style=social" height="17" align="texttop"/> [memU](https://github.com/NevaMind-AI/memU) - an open-source memory framework for AI companions
 - <img src="https://img.shields.io/badge/Google-%234285F4?logo=google&logoColor=red" height="17" align="texttop"/> <img src="https://img.shields.io/github/stars/google-research/reasoning-bank?style=social" height="17" align="texttop"/> [reasoning-bank](https://github.com/google-research/reasoning-bank) - a memory mechanism for agents that learns from both successful and failed trajectories, with reasoning stored as memory content
+- <img src="https://img.shields.io/github/stars/dakera-ai/dakera-mcp?style=social" height="17" align="texttop"/> [dakera-mcp](https://github.com/dakera-ai/dakera-mcp) - self-hosted MCP-native agent memory server with decay-weighted vector recall, 83 MCP tools, RocksDB+HNSW persistence, and 87.8% LoCoMo benchmark score
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
## What is dakera-mcp?

[dakera-mcp](https://github.com/dakera-ai/dakera-mcp) is a self-hosted, MCP-native agent memory server purpose-built for local LLM deployments. It provides persistent, decay-weighted memory that agents can query via 83 native MCP tools — no wrappers, no external API calls.

**Why it fits the Memory Management section:**
- Runs fully self-hosted — ideal for local LLM stacks (Ollama, llama.cpp, LM Studio)
- 87.8% LoCoMo benchmark score — independently verified long-term memory recall
- Decay-weighted vector recall via RocksDB + HNSW means memory fades naturally like human memory, preventing context bloat
- MCP-native: agents connect directly without custom glue code

**Links:**
- GitHub: https://github.com/dakera-ai/dakera-mcp
- Docs: https://docs.dakera.ai