### PR TITLE
Add CrustAI to Tools/Miscellaneous

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,8 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - [Hunyuan3D](https://huggingface.co/collections/tencent/hunyuan3d) - a collection of everything related (models, datasets etc.) to 3D assets generation from Tencent
 - [Hunyuan-GameCraft-1.0](https://huggingface.co/tencent/Hunyuan-GameCraft-1.0) - a novel framework for high-dynamic interactive video generation in game environments
 - [void-model](https://huggingface.co/netflix/void-model) - a model from Netflix that removes objects from videos along with all interactions they induce on the scene — not just secondary effects like shadows and reflections, but physical interactions like objects falling when a person is removed
-
+- [CrustAI](https://github.com/DaveSimoes/CrustAI) - self-hosted private AI assistant for Telegram, WhatsApp, Discord and Slack powered by Ollama
+    
 [Back to Table of Contents](#table-of-contents)
 
 ## Tools


### PR DESCRIPTION
## Addition to Tools/Miscellaneous

Adds CrustAI to the Miscellaneous section under Tools.

**What is CrustAI?**
CrustAI is a self-hosted, privacy-first AI assistant that connects 
Telegram, WhatsApp, Discord and Slack to a local Ollama instance — 
zero cloud, zero data sharing.

**Why does it belong here?**
- Runs 100% locally via Ollama
- Multi-platform messaging integration (Telegram, WhatsApp, Discord, Slack)
- Long-term memory, REST API, and voice support
- MIT license, actively maintained

https://github.com/DaveSimoes/CrustAI