### PR TITLE
Add AI Models Catalog to Explorers, Benchmarks, Leaderboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - [oobabooga benchmark](https://oobabooga.github.io/benchmark.html) - a list sorted by size (on disk) for each score
 - [CyberGym](https://www.cybergym.io/) - evaluating AI agents' real-world cybersecurity capabilities at scale
 - <img src="https://img.shields.io/github/stars/IBM/vakra?style=social" height="17" align="texttop"/> [vakra](https://github.com/IBM/vakra) -  a benchmark for evaluating multi-hop, multi-source tool-calling in AI agents
+- <img src="https://img.shields.io/github/stars/i-need-token/ai-models?style=social" height="17" align="texttop"/> [AI Models Catalog](https://github.com/i-need-token/ai-models) - structured catalog of 4,587+ AI models across 95 providers with pricing, context windows, and capabilities. Interactive catalog: https://i-need-token.github.io/ai-models/
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
## Addition

- **Name:** AI Models Catalog
- **URL:** https://github.com/i-need-token/ai-models
- **Category:** Explorers, Benchmarks, Leaderboards

## Description

Structured catalog of 4,587+ AI models across 95 providers with pricing, context windows, and capabilities. Complements benchmarks by providing the metadata layer (pricing, context, capabilities) needed to make informed decisions. Includes 527 open-weight models relevant for local LLM deployment.

Interactive catalog: https://i-need-token.github.io/ai-models/

## Why this belongs

- **527 open-weight models**: Covers models available for local deployment
- **Pricing data**: Even for local models, shows cloud pricing for comparison
- **Context windows**: Critical for local deployment planning (memory requirements)
- **Capabilities**: Tool calling, reasoning, vision, structured output metadata
- **Interactive catalog**: Filter by open-weight, compare context windows and capabilities