### PR TITLE
Add GreenWatts to Hardware section

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - [Kolosal - LLM Memory calculator](https://www.kolosal.ai/memory-calculator) - estimate the RAM requirements of any GGUF model instantly
 - [LLM Inference VRAM & GPU Requirement Calculator](https://app.linpp2009.com/en/llm-gpu-memory-calculator) - calculate how many GPUs you need to deploy LLMs
 - <img src="https://img.shields.io/github/stars/vosen/ZLUDA?style=social" height="17" align="texttop"/> [ZLUDA](https://github.com/vosen/ZLUDA) - CUDA on non-NVIDIA GPUs
+- <img src="https://img.shields.io/github/stars/Shad107/gpu-dashboard?style=social" height="17" align="texttop"/> [GreenWatts](https://github.com/Shad107/gpu-dashboard) - self-hosted Linux NVIDIA GPU dashboard focused on LLM rigs : tokens-per-watt tracking, fan-curve hysteresis, cgroup-attributed power, throttle-reason decoder
 - [Strix Halo AI Toolboxes](https://strix-halo-toolboxes.com/) - toolboxes for GenAI on AMD Ryzen AI MAX+: containerized environments for LLMs, Image Generation, and Fine-tuning
 - [Strix Halo Wiki](https://strixhalo.wiki/) - a website to gather important information and practical guides for systems powered by AMD Ryzen AI MAX and MAX+ processors
 - <img src="https://img.shields.io/github/stars/paudley/ai-notes?style=social" height="17" align="texttop"/> [ai-notes](https://github.com/paudley/ai-notes) - random AI notes for working with local models or playing around with random machine learning bits


### PR DESCRIPTION
## What

Adds **GreenWatts**, an open-source Linux NVIDIA GPU dashboard built specifically for LLM-rig operators. Python stdlib only, MIT licensed.

Repo: https://github.com/Shad107/gpu-dashboard

## Why this list

Local LLM operators care about hardware efficiency — this tool measures **tokens-per-watt-hour** (not just tok/s), attributes GPU power consumption to cgroups / systemd units (Ollama vs vLLM vs ComfyUI), and decodes throttle reasons in plain language. Complements the existing YouTube channels and calculator entries in the Hardware section with an actual self-hosted monitoring tool.

## Features summary

- tokens-per-watt-hour tracking for llama.cpp / Ollama / vLLM
- Fan curve editor with anti-oscillation hysteresis (no more fan cycling)
- Power attribution per cgroup / systemd unit
- Throttle reason decoder (clocks_event_reasons → plain language)
- Driver/kernel drift detector on each boot
- Multi-channel notifications : Telegram, Discord, ntfy, Pushover, Slack, Matrix, SMTP
- Optional Prometheus /metrics + InfluxDB line-protocol exports

## Checklist

- [x] Open source (MIT)
- [x] Source code available + actively maintained
- [x] Self-hostable, single Python process, no external deps beyond jsonschema
- [x] Format matches existing entries (shields.io badge + link + description)
- [x] Inserted in Hardware section

Happy to adjust wording or move sections if you prefer.