### PR TITLE
Add linkedin2md: zero-dependency LinkedIn→Markdown CLI for LLM analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/Roy3838/Observer?style=social" height="17" align="texttop"/> [Observer](https://github.com/Roy3838/Observer) - local open-source micro-agents that observe, log and react, all while keeping your data private and secure
 - <img src="https://img.shields.io/github/stars/minitap-ai/mobile-use?style=social" height="17" align="texttop"/> [mobile-use](https://github.com/minitap-ai/mobile-use) - a powerful, open-source AI agent that controls your Android or IOS device using natural language
 - <img src="https://img.shields.io/github/stars/gabber-dev/gabber?style=social" height="17" align="texttop"/> [gabber](https://github.com/gabber-dev/gabber) - build AI applications that can see, hear, and speak using your screens, microphones, and cameras as inputs
+- <img src="https://img.shields.io/github/stars/juanmanueldaza/linkedin2md?style=social" height="17" align="texttop"/> [linkedin2md](https://github.com/juanmanueldaza/linkedin2md) - zero-dependency CLI to convert LinkedIn data exports to clean Markdown for LLM analysis, with optional PDF resume generation
 - <img src="https://img.shields.io/github/stars/sevenreasons/promptcat?style=social" height="17" align="texttop"/> [promptcat](https://github.com/sevenreasons/promptcat) - a zero-dependency prompt manager/catalog/library in a single HTML file
 
 [Back to Table of Contents](#table-of-contents)


### PR DESCRIPTION
## linkedin2md

**GitHub:** https://github.com/juanmanueldaza/linkedin2md
**PyPI:** https://pypi.org/project/linkedin2md/
**Stars:** 13 | **Downloads:** 4,500+ on PyPI

### What it does

linkedin2md is a zero-dependency Python CLI that converts LinkedIn ZIP data exports into clean, structured Markdown files — the ideal format for feeding career data into local LLMs (Ollama, LM Studio, NotebookLM, Claude Projects, etc.).

### Why it fits in awesome-local-llm

- **100% local and private** — no API keys, no cloud, no accounts. All processing stays on your machine.
- **Zero core dependencies** — just `pip install linkedin2md` and go. Optional `--pdf` flag via WeasyPrint.
- **Produces LLM-optimized Markdown** from 40+ LinkedIn sections (experience, skills, recommendations, job applications, connections, etc.)
- **Bilingual output** (English/Spanish)
- **SOLID architecture** with `@register_parser` decorator for easy extensibility

### Checklist

- [x] Open-source with GPL-2.0 license
- [x] Runs fully locally, no cloud dependencies
- [x] Active maintenance (v0.3.1 released May 2026)
- [x] 4,500+ PyPI downloads, 13 GitHub stars