### PR TITLE
Add hermes-claude-code-local to Coding Agents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 
 ### Coding Agents
 
+- <img src="https://img.shields.io/github/stars/KaiFelixBennett/hermes-claude-code-local?style=social" height="17" align="texttop"/> [hermes-claude-code-local](https://github.com/KaiFelixBennett/hermes-claude-code-local) - run Claude Code and Hermes Agent locally on llama.cpp via LiteLLM - zero API costs, no rate limits, full privacy
 - <img src="https://img.shields.io/github/stars/sst/opencode?style=social" height="17" align="texttop"/> [opencode](https://github.com/sst/opencode) - a AI coding agent built for the terminal
 - <img src="https://img.shields.io/github/stars/zed-industries/zed?style=social" height="17" align="texttop"/> [zed](https://github.com/zed-industries/zed) - a next-generation code editor designed for high-performance collaboration with humans and AI
 - <img src="https://img.shields.io/github/stars/All-Hands-AI/OpenHands?style=social" height="17" align="texttop"/> [OpenHands](https://github.com/All-Hands-AI/OpenHands) - a platform for software development agents powered by AI


### PR DESCRIPTION
## What this adds

**[hermes-claude-code-local](https://github.com/KaiFelixBennett/hermes-claude-code-local)** - run Claude Code and Hermes Agent locally on llama.cpp via LiteLLM — zero API costs, no rate limits, full privacy.

## Why it fits

- Coding agent setup (Claude Code + Hermes Agent) running fully locally
- Uses llama.cpp as the inference backend (fits the 'local LLM' theme)
- LiteLLM bridges the Anthropic API format to any local OpenAI-compatible endpoint
- Real-world validated: 4-hour autonomous coding session, 7.2M tokens, \ cost (vs \ on Claude Opus 4.7)

## Category

Fits in **Coding Agents** — it's a complete local coding agent stack rather than a standalone model or inference engine.