### PR TITLE
Add Prompter - terminal-based Ollama evaluation tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/Giskard-AI/giskard?style=social" height="17" align="texttop"/> [giskard](https://github.com/Giskard-AI/giskard) - an open-source evaluation & testing for AI & LLM systems
 - <img src="https://img.shields.io/github/stars/Agenta-AI/agenta?style=social" height="17" align="texttop"/> [agenta](https://github.com/Agenta-AI/agenta) - an open-source LLMOps platform: prompt playground, prompt management, LLM evaluation, and LLM observability all in one place
 - <img src="https://img.shields.io/badge/NVIDIA-%25?logo=nvidia&labelColor=white" height="17" align="texttop"/> <img src="https://img.shields.io/github/stars/NVIDIA-NeMo/evaluator?style=social" height="17" align="texttop"/> [Evaluator](https://github.com/NVIDIA-NeMo/evaluator) - open-source library for scalable, reproducible evaluation of AI models and benchmarks
+- <img src="https://img.shields.io/github/stars/whonixnetworks/prompter?style=social" height="17" align="texttop"/> [Prompter](https://github.com/whonixnetworks/prompter) - Terminal-based multi-model comparison, benchmarking, and structured evaluation (Council debates, Tribunal cross-examination, RALPH self-review) for Ollama. Zero dependencies.
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
## Summary

Add [Prompter](https://github.com/whonixnetworks/prompter) to the Testing, Evaluation and Observability section.

## What is Prompter?

Prompter is a terminal-based multi-model comparison and evaluation tool for Ollama with zero external dependencies (pure Python stdlib). It supports:

- **Multi-model side-by-side comparison** with live streaming
- **Benchmarking** - standardized capability and tool tests for each model
- **Council mode** - persona-based debate (Expert, Skeptic, Advocate) with synthesis verdict
- **Tribunal/Bully mode** - adversarial cross-examination with arbiter ruling
- **RALPH self-review** - iterative self-critique loop
- **Built-in tool ecosystem** - web search, URL fetch, file read, Python/shell sandbox, RSS, embeddings, and more

Prompter is distributed as a single Python file with zero pip dependencies, making it trivial to install and use alongside any Ollama setup.