### PR TITLE
Add ccg-router to Tools > Models

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/AlexsJones/llmfit?style=social" height="17" align="texttop"/> [llmfit](https://github.com/AlexsJones/llmfit) - hundreds of models & providers, one command to find what runs on your hardware
 - <img src="https://img.shields.io/github/stars/dottxt-ai/outlines?style=social" height="17" align="texttop"/> [outlines](https://github.com/dottxt-ai/outlines) - structured outputs for LLMs
 - <img src="https://img.shields.io/github/stars/mostlygeek/llama-swap?style=social" height="17" align="texttop"/> [llama-swap](https://github.com/mostlygeek/llama-swap) - reliable model swapping for any local OpenAI compatible server - llama.cpp, vllm, etc.
+- <img src="https://img.shields.io/github/stars/XZXY-AI/ccg-router?style=social" height="17" align="texttop"/> [ccg-router](https://github.com/XZXY-AI/ccg-router) - local-first Go daemon that routes Claude Code and Codex CLI to any OpenAI- or Anthropic-compatible backend (Ollama, LM Studio, llama.cpp, vLLM) from one port, with a local SQLite usage ledger and dashboard
 - <img src="https://img.shields.io/github/stars/guidance-ai/llguidance?style=social" height="17" align="texttop"/> [llguidance](https://github.com/guidance-ai/llguidance) - super-fast structured outputs
 
 [Back to Table of Contents](#table-of-contents)


### PR DESCRIPTION
Adding **ccg-router** under **Tools > Models**, right next to llama-swap since both are routing layers in front of OpenAI-compatible backends.

ccg-router is an open-source (Apache-2.0) local-first Go daemon that lets you point **Claude Code (Anthropic-compatible) and Codex CLI (OpenAI-compatible)** at any local or remote backend — Ollama, LM Studio, llama.cpp, vLLM, etc. — from a single port, with routing strategies and a local SQLite usage ledger + dashboard. Provider keys stay on your machine; no hosted control plane.

Repo: https://github.com/XZXY-AI/ccg-router

Entry follows the existing stars-badge line format. Happy to move it to **Miscellaneous** if you feel that's a better home — your call. Thanks for maintaining the list!