### PR TITLE
Add JARVIS - local-first holographic AI desktop assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/oobabooga/text-generation-webui?style=social" height="17" align="texttop"/> [Text generation web UI](https://github.com/oobabooga/text-generation-webui) - LLM UI with advanced features, easy setup, and multiple backend support
 - <img src="https://img.shields.io/github/stars/SillyTavern/SillyTavern?style=social" height="17" align="texttop"/> [SillyTavern](https://github.com/SillyTavern/SillyTavern) - LLM Frontend for Power Users
 - <img src="https://img.shields.io/github/stars/n4ze3m/page-assist?style=social" height="17" align="texttop"/> [Page Assist](https://github.com/n4ze3m/page-assist) - Use your locally running AI models to assist you in your web browsing
+- <img src="https://img.shields.io/github/stars/Dix01/JARVIS?style=social" height="17" align="texttop"/> [JARVIS](https://github.com/Dix01/JARVIS) - A local-first holographic AI desktop assistant for Windows. Voice control (Whisper STT + Piper TTS), webcam vision, FLUX local image gen, image-to-3D (TRELLIS/Hunyuan3D), 80+ tools, agent swarm. Electron + React + Three.js HUD, FastAPI backend. No cloud required.
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
## What is this?

[JARVIS](https://github.com/Dix01/JARVIS) is an open-source, local-first holographic AI desktop assistant for Windows.

It fits the **User Interfaces** section: a full Electron + React + Three.js frontend for any local LLM (Ollama, LM Studio, vLLM, etc.), with:
- Voice: Whisper STT + Piper TTS (local, MCU-butler voice)
- Vision: webcam snapshot + analysis, OCR, screen capture
- Image gen: FLUX.2-klein-4B (local, ~4 steps, 16 GB GPU)
- Image-to-3D: TRELLIS.2 / Hunyuan3D (local GLB output)
- 80+ tools across 12 plugin groups
- 9-role agent swarm with autonomous plan-execute-reflect loop
- FastAPI backend, SQLite memory with semantic recall

Repo: https://github.com/Dix01/JARVIS