### PR TITLE
Add consciousness-server to Memory Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,8 +356,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/LMCache/LMCache?style=social" height="17" align="texttop"/> [LMCache](https://github.com/LMCache/LMCache) - supercharge your LLM with the fastest KV Cache Layer
 - <img src="https://img.shields.io/github/stars/NevaMind-AI/memU?style=social" height="17" align="texttop"/> [memU](https://github.com/NevaMind-AI/memU) - an open-source memory framework for AI companions
 - <img src="https://img.shields.io/badge/Google-%234285F4?logo=google&logoColor=red" height="17" align="texttop"/> <img src="https://img.shields.io/github/stars/google-research/reasoning-bank?style=social" height="17" align="texttop"/> [reasoning-bank](https://github.com/google-research/reasoning-bank) - a memory mechanism for agents that learns from both successful and failed trajectories, with reasoning stored as memory content
-
-[Back to Table of Contents](#table-of-contents)
+- <img src="https://img.shields.io/github/stars/build-on-ai/consciousness-server?style=social" height="17" align="texttop"/> [consciousness-server](https://github.com/build-on-ai/consciousness-server) - self-hosted shared-memory layer for multi-agent setups: semantic search, agent registry, ed25519 auth, runs fully local
 
 ### Testing, Evaluation and Observability
 


### PR DESCRIPTION
Adds [consciousness-server](https://github.com/build-on-ai/consciousness-server) under **Tools → Memory Management** (disclosure: I maintain the project).

A self-hosted shared-memory layer for multi-agent setups: notes/chat/tasks over plain HTTP, semantic search (local embeddings via Ollama `nomic-embed-text`), an agent registry, and opt-in ed25519 auth — up with `docker compose up`. Fits the local-first theme: everything runs on your own hardware, nothing leaves the host. AGPL-3.0.

Placed at the end of Memory Management. Happy to tweak wording or placement.