### PR TITLE
Add Strix Halo local LLM guide to hardware resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/vosen/ZLUDA?style=social" height="17" align="texttop"/> [ZLUDA](https://github.com/vosen/ZLUDA) - CUDA on non-NVIDIA GPUs
 - [Strix Halo AI Toolboxes](https://strix-halo-toolboxes.com/) - toolboxes for GenAI on AMD Ryzen AI MAX+: containerized environments for LLMs, Image Generation, and Fine-tuning
 - [Strix Halo Wiki](https://strixhalo.wiki/) - a website to gather important information and practical guides for systems powered by AMD Ryzen AI MAX and MAX+ processors
+- [Strix Halo local LLM guide](https://github.com/hogeheer499-commits/strix-halo-guide) - reproducible Ryzen AI MAX+ 395 / Radeon 8060S / gfx1151 local LLM guide with raw logs, direct/server benchmark labels, and Vulkan/RADV vs ROCm/HIP evidence
 - <img src="https://img.shields.io/github/stars/paudley/ai-notes?style=social" height="17" align="texttop"/> [ai-notes](https://github.com/paudley/ai-notes) - random AI notes for working with local models or playing around with random machine learning bits
 
 [Back to Table of Contents](#table-of-contents)


### PR DESCRIPTION
Adds a reproducible Strix Halo / Ryzen AI MAX+ 395 / Radeon 8060S local LLM guide to the Hardware section.\n\nIt complements the existing Strix Halo Toolboxes and Strix Halo Wiki links with raw logs and benchmark labeling for direct vs server routes, Vulkan/RADV vs ROCm/HIP, and community reproductions.