### PR TITLE
Add Atomic Chat to User Interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 ## User Interfaces
 
 - <img src="https://img.shields.io/github/stars/open-webui/open-webui?style=social" height="17" align="texttop"/> [Open WebUI](https://github.com/open-webui/open-webui) - User-friendly AI Interface (Supports Ollama, OpenAI API, ...)
+- <img src="https://img.shields.io/github/stars/AtomicBot-ai/Atomic-Chat?style=social" height="17" align="texttop"/> [Atomic Chat](https://github.com/AtomicBot-ai/Atomic-Chat) - GUI-first local AI chat (macOS/Windows/Linux/iOS/Android), runs GGUF & MLX, OpenAI-compatible server, MCP support
 - <img src="https://img.shields.io/github/stars/lobehub/lobe-chat?style=social" height="17" align="texttop"/> [Lobe Chat](https://github.com/lobehub/lobe-chat) - an open-source, modern design AI chat framework
 - <img src="https://img.shields.io/github/stars/oobabooga/text-generation-webui?style=social" height="17" align="texttop"/> [Text generation web UI](https://github.com/oobabooga/text-generation-webui) - LLM UI with advanced features, easy setup, and multiple backend support
 - <img src="https://img.shields.io/github/stars/SillyTavern/SillyTavern?style=social" height="17" align="texttop"/> [SillyTavern](https://github.com/SillyTavern/SillyTavern) - LLM Frontend for Power Users


### PR DESCRIPTION
Adds [Atomic Chat](https://github.com/AtomicBot-ai/Atomic-Chat) to the User Interfaces section — an open-source, GUI-first local AI app (macOS/Windows/Linux/iOS/Android). Runs GGUF and MLX models locally with an OpenAI-compatible server at localhost:1337 and MCP support. Apache-2.0. Single-line addition.