### PR TITLE
feat: add TWZRD Agent Intel MCP server to Model Context Protocol section

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/awslabs/mcp?style=social" height="17" align="texttop"/> [awslabs/mcp](https://github.com/awslabs/mcp) - AWS MCP Servers — helping you get the most out of AWS, wherever you use MCP
 - <img src="https://img.shields.io/github/stars/sooperset/mcp-atlassian?style=social" height="17" align="texttop"/> [mcp-atlassian](https://github.com/sooperset/mcp-atlassian) - MCP server for Atlassian tools (Confluence, Jira)
 - <img src="https://img.shields.io/github/stars/bytebase/dbhub?style=social" height="17" align="texttop"/> [dbhub](https://github.com/bytebase/dbhub) - zero-dependency, token-efficient database MCP server for Postgres, MySQL, SQL Server, MariaDB, SQLite
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - trust scoring and x402 payment verification for AI agents on Solana; zero-install streamable-HTTP MCP endpoint
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **Model Context Protocol** section.

**TWZRD Agent Intel** is a production MCP server providing trust scoring and x402 payment verification for AI agents on Solana:

- **Zero-install** streamable-HTTP endpoint: `{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}`
- **Free tools**: `resolve_agent`, `score_agent`, `preflight_check`, `verify_trust_receipt` — score any Solana wallet before trusting it
- **Paid tool**: `get_trust_receipt` — HTTP 402, <1s USDC settlement on Solana mainnet
- Also on PyPI: `pip install twzrd-agent-intel`

Relevant to this list because it extends local LLM agents with verifiable identity and payment infrastructure for calling paid APIs autonomously.