### PR TITLE
Add Local-AI-Models.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - [SWE-rebench](https://swe-rebench.com/) - a continuously evolving and decontaminated benchmark for software engineering LLMs
 - <img src="https://img.shields.io/github/stars/petergpt/bullshit-benchmark?style=social" height="17" align="texttop"/> [BullshitBench](https://github.com/petergpt/bullshit-benchmark) - measure whether AI models challenge nonsensical prompts instead of confidently answering them
 - [LLM Explorer](https://llm-explorer.com/) - explore list of the open-source LLM models
+- [Local-AI-Models.ai](https://local-ai-models.ai) - Filterable catalog of open-weight models and agent frameworks sized to your GPU and budget.
 - [Dubesor LLM Benchmark table](https://dubesor.de/benchtable) - small-scale manual performance comparison benchmark
 - [oobabooga benchmark](https://oobabooga.github.io/benchmark.html) - a list sorted by size (on disk) for each score
 - [CyberGym](https://www.cybergym.io/) - evaluating AI agents' real-world cybersecurity capabilities at scale


### PR DESCRIPTION
Adds Local-AI-Models.ai to *Explorers, Benchmarks, Leaderboards* — a free, no-login reference that helps you decide which open-weight models your hardware can run and what to buy to run more (filterable catalog of models + agent frameworks by VRAM, quantization, and license; includes a model recommender, PC builder, and token-speed simulator).

Disclosure: I maintain this resource — happy to adjust wording or placement.