### PR TITLE
Add pyimgtag to Tools/Miscellaneous

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/minitap-ai/mobile-use?style=social" height="17" align="texttop"/> [mobile-use](https://github.com/minitap-ai/mobile-use) - a powerful, open-source AI agent that controls your Android or IOS device using natural language
 - <img src="https://img.shields.io/github/stars/gabber-dev/gabber?style=social" height="17" align="texttop"/> [gabber](https://github.com/gabber-dev/gabber) - build AI applications that can see, hear, and speak using your screens, microphones, and cameras as inputs
 - <img src="https://img.shields.io/github/stars/sevenreasons/promptcat?style=social" height="17" align="texttop"/> [promptcat](https://github.com/sevenreasons/promptcat) - a zero-dependency prompt manager/catalog/library in a single HTML file
+- <img src="https://img.shields.io/github/stars/kurok/pyimgtag?style=social" height="17" align="texttop"/> [pyimgtag](https://github.com/kurok/pyimgtag) - a CLI photo tagger that uses a local vision model (Gemma via Ollama by default) to add searchable tags, scene categories, and EXIF-GPS-derived location to images, with query, scoring, and cleanup commands
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
## What

Adds [pyimgtag](https://github.com/kurok/pyimgtag) ([PyPI](https://pypi.org/project/pyimgtag/)) to the **Tools → Miscellaneous** section.

## Why it fits

pyimgtag is a command-line application that uses a local vision model (Gemma via Ollama, by default) to automatically tag photos with searchable keywords, scene categories, and EXIF-GPS-derived location data. It also provides query, scoring, and cleanup commands for the resulting library. Local on-device inference by default; optionally accepts remote Ollama or cloud backends via `--backend`.

- MIT license
- Python 3.11–3.14, macOS / Linux / Windows
- Available on PyPI

## Guide compliance

- Single entry, no unrelated changes
- Follows the existing `- <stars-badge> [name](url) - description` format
- No trailing whitespace on the new line
- No ToC update needed (section already listed)