### PR TITLE
Add llm-swarm-router — local LAN mesh router for oMLX/Ollama/vLLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/AlexsJones/llmfit?style=social" height="17" align="texttop"/> [llmfit](https://github.com/AlexsJones/llmfit) - hundreds of models & providers, one command to find what runs on your hardware
 - <img src="https://img.shields.io/github/stars/dottxt-ai/outlines?style=social" height="17" align="texttop"/> [outlines](https://github.com/dottxt-ai/outlines) - structured outputs for LLMs
 - <img src="https://img.shields.io/github/stars/mostlygeek/llama-swap?style=social" height="17" align="texttop"/> [llama-swap](https://github.com/mostlygeek/llama-swap) - reliable model swapping for any local OpenAI compatible server - llama.cpp, vllm, etc.
+- <img src="https://img.shields.io/github/stars/matthewdcage/llm-swarm-router?style=social" height="17" align="texttop"/> [llm-swarm-router](https://github.com/matthewdcage/llm-swarm-router) - LAN mesh router for local LLM backends (oMLX, Ollama, LM Studio, vLLM) — one OpenAI + Anthropic API on `:11400`
 - <img src="https://img.shields.io/github/stars/guidance-ai/llguidance?style=social" height="17" align="texttop"/> [llguidance](https://github.com/guidance-ai/llguidance) - super-fast structured outputs
 
 [Back to Table of Contents](#table-of-contents)


### PR DESCRIPTION
Adds **llm-swarm-router** (netllm) under Tools → Models.

Self-hosted mesh router for local LLM backends — OpenAI `/v1` + Anthropic Messages on `:11400`, mDNS LAN peers. Discovers oMLX, Ollama, LM Studio, vLLM, and custom OpenAI-compat endpoints; complements inference engines with one stable URL for coding agents (Cursor, Claude Code, Codex).

- https://github.com/matthewdcage/llm-swarm-router
- https://github.com/matthewdcage/llm-swarm-router/releases/latest
- https://github.com/matthewdcage/llm-swarm-router/blob/main/docs/editor-integration.md

MIT. Not a cloud provider aggregator — local LAN mesh only.