### PR TITLE
Add What LLM Can I Run hardware checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/youtube/channel/subscribers/UC8h2Sf-yyo1WXeEUr-OHgyg?style=social" height="17" align="texttop"/> [Miyconst](https://www.youtube.com/@Miyconst) - tests of various types of hardware capable of running LLMs
 - [Kolosal - LLM Memory calculator](https://www.kolosal.ai/memory-calculator) - estimate the RAM requirements of any GGUF model instantly
 - [LLM Inference VRAM & GPU Requirement Calculator](https://app.linpp2009.com/en/llm-gpu-memory-calculator) - calculate how many GPUs you need to deploy LLMs
-- [What LLM Can I Run?](https://whatsmy.fyi/what-llm-can-i-run) - detects your hardware live in the browser and checks it against 41 open-weight models, with per-quantization sizes, min RAM and tok/s estimates
+- [What LLM Can I Run?](https://whatsmy.fyi/what-llm-can-i-run) - detects your hardware live in the browser and checks it against 70+ open-weight models, with per-quantization sizes, min RAM and tok/s estimates
 - <img src="https://img.shields.io/github/stars/vosen/ZLUDA?style=social" height="17" align="texttop"/> [ZLUDA](https://github.com/vosen/ZLUDA) - CUDA on non-NVIDIA GPUs
 - [Strix Halo AI Toolboxes](https://strix-halo-toolboxes.com/) - toolboxes for GenAI on AMD Ryzen AI MAX+: containerized environments for LLMs, Image Generation, and Fine-tuning
 - [Strix Halo Wiki](https://strixhalo.wiki/) - a website to gather important information and practical guides for systems powered by AMD Ryzen AI MAX and MAX+ processors

--- a/README.md
+++ b/README.md
@@ -430,6 +430,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/youtube/channel/subscribers/UC8h2Sf-yyo1WXeEUr-OHgyg?style=social" height="17" align="texttop"/> [Miyconst](https://www.youtube.com/@Miyconst) - tests of various types of hardware capable of running LLMs
 - [Kolosal - LLM Memory calculator](https://www.kolosal.ai/memory-calculator) - estimate the RAM requirements of any GGUF model instantly
 - [LLM Inference VRAM & GPU Requirement Calculator](https://app.linpp2009.com/en/llm-gpu-memory-calculator) - calculate how many GPUs you need to deploy LLMs
+- [What LLM Can I Run?](https://whatsmy.fyi/what-llm-can-i-run) - detects your hardware live in the browser and checks it against 41 open-weight models, with per-quantization sizes, min RAM and tok/s estimates
 - <img src="https://img.shields.io/github/stars/vosen/ZLUDA?style=social" height="17" align="texttop"/> [ZLUDA](https://github.com/vosen/ZLUDA) - CUDA on non-NVIDIA GPUs
 - [Strix Halo AI Toolboxes](https://strix-halo-toolboxes.com/) - toolboxes for GenAI on AMD Ryzen AI MAX+: containerized environments for LLMs, Image Generation, and Fine-tuning
 - [Strix Halo Wiki](https://strixhalo.wiki/) - a website to gather important information and practical guides for systems powered by AMD Ryzen AI MAX and MAX+ processors


### PR DESCRIPTION
## What this adds
[What LLM Can I Run?](https://whatsmy.fyi/what-llm-can-i-run) — a free, in-browser hardware checker for local LLMs, added to the Hardware section next to the other memory calculators.

## Why it belongs here
- Detects the visitor's hardware live via WebGPU (incl. an optional memory-bandwidth benchmark) instead of asking for manual specs
- Covers 70+ open-weight models: per-quantization download sizes, min RAM, KV-cache-by-context and tok/s estimates per GPU class
- All formulas are public: https://whatsmy.fyi/what-llm-can-i-run/methodology
- Free, no signup, no ads, zero data stored (everything runs client-side)

Formatting follows the existing Hardware entries. Happy to adjust wording or placement.