### PR TITLE
Add nanocoder to Coding Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/humanlayer/humanlayer?style=social" height="17" align="texttop"/> [humanlayer](https://github.com/humanlayer/humanlayer) - the best way to get AI coding agents to solve hard problems in complex codebases
 - <img src="https://img.shields.io/github/stars/ThePrimeagen/99?style=social" height="17" align="texttop"/> [99](https://github.com/ThePrimeagen/99) - neovim AI agent done right
 - <img src="https://img.shields.io/github/stars/carlrobertoh/ProxyAI?style=social" height="17" align="texttop"/> [ProxyAI](https://github.com/carlrobertoh/ProxyAI) - the leading open-source AI copilot for JetBrains
+- <img src="https://img.shields.io/github/stars/Nano-Collective/nanocoder?style=social" height="17" align="texttop"/> [nanocoder](https://github.com/Nano-Collective/nanocoder) - a local-first, open-source coding agent for your terminal that runs on local or any OpenAI-compatible models
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Adds [nanocoder](https://github.com/Nano-Collective/nanocoder) to the Coding Agents section.

nanocoder is a local-first, open-source coding agent for the terminal. It runs against local models or any OpenAI-compatible endpoint, so it fits this list's local-LLM focus: your code stays on your machine.

- Appended to the end of the Coding Agents section
- Matches the existing format, including the GitHub stars badge
- Link verified