### PR TITLE
Add Prismix — real-time status monitoring for 75+ cloud AI API providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/minitap-ai/mobile-use?style=social" height="17" align="texttop"/> [mobile-use](https://github.com/minitap-ai/mobile-use) - a powerful, open-source AI agent that controls your Android or IOS device using natural language
 - <img src="https://img.shields.io/github/stars/gabber-dev/gabber?style=social" height="17" align="texttop"/> [gabber](https://github.com/gabber-dev/gabber) - build AI applications that can see, hear, and speak using your screens, microphones, and cameras as inputs
 - <img src="https://img.shields.io/github/stars/sevenreasons/promptcat?style=social" height="17" align="texttop"/> [promptcat](https://github.com/sevenreasons/promptcat) - a zero-dependency prompt manager/catalog/library in a single HTML file
+- [Prismix](https://prismix.dev) - Real-time status monitoring for 75+ AI cloud API providers (OpenAI, Anthropic, Gemini, Groq, Mistral, xAI, and more). Useful for fallback routing — know when a cloud provider is down and when it recovers. Free, embeddable status badges.
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Adds Prismix as a monitoring tool for cloud AI API providers.

When running local LLMs, it's common to route requests to cloud providers (OpenAI, Anthropic, Gemini, Groq, Mistral, xAI) as fallback or for specific tasks. Prismix helps with that by showing real-time status (up/degraded/down) for 75+ providers:

https://prismix.dev/status

Useful for:
- Knowing which cloud provider to fall back to when your primary is down
- Getting email/webhook alerts when a provider recovers
- Embedding status badges in your own dashboards

Free, no signup required to browse.