### PR TITLE
Add lilbee to Tools > Retrieval-Augmented Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/onyx-dot-app/onyx?style=social" height="17" align="texttop"/> [onyx](https://github.com/onyx-dot-app/onyx) - the AI platform connected to your company's docs, apps, and people
 - <img src="https://img.shields.io/github/stars/zilliztech/claude-context?style=social" height="17" align="texttop"/> [claude-context](https://github.com/zilliztech/claude-context) - make entire codebase the context for any coding agent
 - <img src="https://img.shields.io/github/stars/pipeshub-ai/pipeshub-ai?style=social" height="17" align="texttop"/> [pipeshub-ai](https://github.com/pipeshub-ai/pipeshub-ai) - a fully extensible and explainable workplace AI platform for enterprise search and workflow automation
-- <img src="https://img.shields.io/github/stars/tobocop2/lilbee?style=social" height="17" align="texttop"/> [lilbee](https://github.com/tobocop2/lilbee) - local-first RAG search engine that runs and manages the models itself, indexes your files and code, crawls the websites you point it at, and answers with citations to the source
+- <img src="https://img.shields.io/github/stars/tobocop2/lilbee?style=social" height="17" align="texttop"/> [lilbee](https://github.com/tobocop2/lilbee) - local-first RAG search engine that runs and manages its own models, or uses your existing Ollama or LM Studio, indexes your files and code, crawls the websites you point it at, and answers with citations to the source
 
 [Back to Table of Contents](#table-of-contents)
 

--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/onyx-dot-app/onyx?style=social" height="17" align="texttop"/> [onyx](https://github.com/onyx-dot-app/onyx) - the AI platform connected to your company's docs, apps, and people
 - <img src="https://img.shields.io/github/stars/zilliztech/claude-context?style=social" height="17" align="texttop"/> [claude-context](https://github.com/zilliztech/claude-context) - make entire codebase the context for any coding agent
 - <img src="https://img.shields.io/github/stars/pipeshub-ai/pipeshub-ai?style=social" height="17" align="texttop"/> [pipeshub-ai](https://github.com/pipeshub-ai/pipeshub-ai) - a fully extensible and explainable workplace AI platform for enterprise search and workflow automation
+- <img src="https://img.shields.io/github/stars/tobocop2/lilbee?style=social" height="17" align="texttop"/> [lilbee](https://github.com/tobocop2/lilbee) - local-first RAG search engine that runs and manages the models itself, indexes your files and code, crawls the websites you point it at, and answers with citations to the source
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Adds [lilbee](https://github.com/tobocop2/lilbee) to Tools > Retrieval-Augmented Generation, using the stars-shield format the section uses.

lilbee is a local-first search engine you can talk to. It finds, runs, and manages local GGUF models itself (or uses your existing Ollama or LM Studio), indexes your files and code, crawls the websites you point it at, retrieves and reranks, and answers with a citation. It ships as a single executable or a `pip install`, with no Docker, no containers, and no separate vector database or model server to run. The manager is one to one with [llama.cpp](https://github.com/ggml-org/llama.cpp) and pulls any GGUF from Hugging Face.

Site: https://lilbee.sh. Free Obsidian plugin for non-terminal users: https://community.obsidian.md/plugins/lilbee. Multi-GPU serving and an opencode integration are coming in https://github.com/tobocop2/lilbee/pull/267.
