### PR TITLE
Add AccInt to Memory Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/LMCache/LMCache?style=social" height="17" align="texttop"/> [LMCache](https://github.com/LMCache/LMCache) - supercharge your LLM with the fastest KV Cache Layer
 - <img src="https://img.shields.io/github/stars/NevaMind-AI/memU?style=social" height="17" align="texttop"/> [memU](https://github.com/NevaMind-AI/memU) - an open-source memory framework for AI companions
 - <img src="https://img.shields.io/badge/Google-%234285F4?logo=google&logoColor=red" height="17" align="texttop"/> <img src="https://img.shields.io/github/stars/google-research/reasoning-bank?style=social" height="17" align="texttop"/> [reasoning-bank](https://github.com/google-research/reasoning-bank) - a memory mechanism for agents that learns from both successful and failed trajectories, with reasoning stored as memory content
+- <img src="https://img.shields.io/github/stars/maxbaluev/accreted-intelligence?style=social" height="17" align="texttop"/> [AccInt](https://github.com/maxbaluev/accreted-intelligence) - local-first MCP memory layer for coding agents that retrieves scored project context, records outcomes, and coordinates work across sessions
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
## Summary
- Add AccInt to the Memory Management section using the existing GitHub-stars badge format.

## Fit
AccInt is a local-first MCP memory layer for coding agents. It retrieves scored project context, records outcomes, and coordinates work across sessions, so it fits alongside the agent-memory tools already listed in this section.

## Validation
- `git diff --check`
- `curl -I -L https://github.com/maxbaluev/accreted-intelligence` returns HTTP 200
- `curl -I -L 'https://img.shields.io/github/stars/maxbaluev/accreted-intelligence?style=social'` returns HTTP 200 image/svg+xml
