### PR TITLE
Add inferbench to Tools > Models

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 ### Models
 
 - <img src="https://img.shields.io/github/stars/AlexsJones/llmfit?style=social" height="17" align="texttop"/> [llmfit](https://github.com/AlexsJones/llmfit) - hundreds of models & providers, one command to find what runs on your hardware
+- <img src="https://img.shields.io/github/stars/JoniMartin27/inferbench?style=social" height="17" align="texttop"/> [inferbench](https://github.com/JoniMartin27/inferbench) - benchmark local inference speed (tokens/sec) on your own hardware; 124-model catalog, optimal-quant picker, and an MCP serve mode
 - <img src="https://img.shields.io/github/stars/dottxt-ai/outlines?style=social" height="17" align="texttop"/> [outlines](https://github.com/dottxt-ai/outlines) - structured outputs for LLMs
 - <img src="https://img.shields.io/github/stars/mostlygeek/llama-swap?style=social" height="17" align="texttop"/> [llama-swap](https://github.com/mostlygeek/llama-swap) - reliable model swapping for any local OpenAI compatible server - llama.cpp, vllm, etc.
 - <img src="https://img.shields.io/github/stars/guidance-ai/llguidance?style=social" height="17" align="texttop"/> [llguidance](https://github.com/guidance-ai/llguidance) - super-fast structured outputs

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 ### Models
 
 - <img src="https://img.shields.io/github/stars/AlexsJones/llmfit?style=social" height="17" align="texttop"/> [llmfit](https://github.com/AlexsJones/llmfit) - hundreds of models & providers, one command to find what runs on your hardware
-- <img src="https://img.shields.io/github/stars/JoniMartin27/inferbench?style=social" height="17" align="texttop"/> [inferbench](https://github.com/JoniMartin27/inferbench) - benchmark local inference speed (tokens/sec) on your own hardware; 124-model catalog, optimal-quant picker, and an MCP serve mode
+- <img src="https://img.shields.io/github/stars/JoniMartin27/inferbench?style=social" height="17" align="texttop"/> [inferbench](https://fervon.dev/inferbench/) - benchmark local inference speed (tokens/sec) on your own hardware; 124-model catalog, optimal-quant picker, and an MCP serve mode
 - <img src="https://img.shields.io/github/stars/dottxt-ai/outlines?style=social" height="17" align="texttop"/> [outlines](https://github.com/dottxt-ai/outlines) - structured outputs for LLMs
 - <img src="https://img.shields.io/github/stars/mostlygeek/llama-swap?style=social" height="17" align="texttop"/> [llama-swap](https://github.com/mostlygeek/llama-swap) - reliable model swapping for any local OpenAI compatible server - llama.cpp, vllm, etc.
 - <img src="https://img.shields.io/github/stars/guidance-ai/llguidance?style=social" height="17" align="texttop"/> [llguidance](https://github.com/guidance-ai/llguidance) - super-fast structured outputs


### PR DESCRIPTION
Adds [inferbench](https://github.com/JoniMartin27/inferbench) to **Tools > Models**, right next to `llmfit`.

inferbench is a local-first CLI that benchmarks real inference speed (tokens/sec) of GGUF / llama.cpp models on your own hardware. It ships a 124-model catalog, picks the optimal quantization for your GPU, and has an MCP serve mode so clients (Claude Desktop, Cursor) can drive local inference.

- Repo: https://github.com/JoniMartin27/inferbench
- License: MIT
- Same "what runs on your hardware" spirit as the neighboring `llmfit` entry, with a focus on measured throughput.