### PR TITLE
Add ForestHub edge-agents to Agent Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/badboysm890/ClaraVerse?style=social" height="17" align="texttop"/> [ClaraVerse](https://github.com/badboysm890/ClaraVerse) - privacy-first, fully local AI workspace with Ollama LLM chat, tool calling, agent builder, Stable Diffusion, and embedded n8n-style automation
 - <img src="https://img.shields.io/badge/NVIDIA-%25?logo=nvidia&labelColor=white" height="17" align="texttop"/> <img src="https://img.shields.io/github/stars/NVIDIA/NeMo-Agent-Toolkit?style=social" height="17" align="texttop"/> [NeMo-Agent-Toolkit](https://github.com/NVIDIA/NeMo-Agent-Toolkit) - an open-source library for efficiently connecting and optimizing teams of AI agents
 - <img src="https://img.shields.io/github/stars/deepsense-ai/ragbits?style=social" height="17" align="texttop"/> [ragbits](https://github.com/deepsense-ai/ragbits) - building blocks for rapid development of GenAI applications
+- <img src="https://img.shields.io/github/stars/ForestHubAI/edge-agents?style=social" height="17" align="texttop"/> [ForestHub edge-agents](https://github.com/ForestHubAI/edge-agents) - the ~30 MB open-source agent runtime from [ForestHub](https://foresthub.ai); runs offline on Linux edge devices with local models (llama.cpp / Ollama / vLLM) alongside cloud LLMs, plus hardware I/O nodes and a visual builder
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Adds [ForestHub edge-agents](https://github.com/ForestHubAI/edge-agents) to *Tools → Agent Frameworks*. It is a ~30 MB open-source agent runtime for Linux edge devices that runs offline with local models via llama.cpp / Ollama / vLLM alongside cloud LLMs, which fits this list's local-first focus. Follows the existing entry format (stars badge + link + one-line description).