### PR TITLE
Add Skales (local-first AI desktop agent)

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/badboysm890/ClaraVerse?style=social" height="17" align="texttop"/> [ClaraVerse](https://github.com/badboysm890/ClaraVerse) - privacy-first, fully local AI workspace with Ollama LLM chat, tool calling, agent builder, Stable Diffusion, and embedded n8n-style automation
 - <img src="https://img.shields.io/badge/NVIDIA-%25?logo=nvidia&labelColor=white" height="17" align="texttop"/> <img src="https://img.shields.io/github/stars/NVIDIA/NeMo-Agent-Toolkit?style=social" height="17" align="texttop"/> [NeMo-Agent-Toolkit](https://github.com/NVIDIA/NeMo-Agent-Toolkit) - an open-source library for efficiently connecting and optimizing teams of AI agents
 - <img src="https://img.shields.io/github/stars/deepsense-ai/ragbits?style=social" height="17" align="texttop"/> [ragbits](https://github.com/deepsense-ai/ragbits) - building blocks for rapid development of GenAI applications
+- <img src="https://img.shields.io/github/stars/skalesapp/skales?style=social" height="17" align="texttop"/> [Skales](https://github.com/skalesapp/skales) - a local-first AI desktop agent that runs goals autonomously in the background, with multi-agent teams, desktop and browser automation, and 15+ providers or fully offline via Ollama
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Adds **Skales** to *Tools → Agent Frameworks*.

Skales is a local-first AI desktop agent for Windows, macOS, Linux and Android: you hand it a goal and it runs autonomously in the background, with multi-agent teams (A2A), desktop and browser automation, MCP support, and 15+ providers or fully offline via Ollama. No Docker, no terminal, one-click install. Your files stay on your machine. Source-available under BSL-1.1 (converts to Apache-2.0 in 2030).

It sits naturally next to ClaraVerse and anything-llm in the Agent Frameworks list. Repo: https://github.com/skalesapp/skales