### PR TITLE
Add localharness (Agent Frameworks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/badboysm890/ClaraVerse?style=social" height="17" align="texttop"/> [ClaraVerse](https://github.com/badboysm890/ClaraVerse) - privacy-first, fully local AI workspace with Ollama LLM chat, tool calling, agent builder, Stable Diffusion, and embedded n8n-style automation
 - <img src="https://img.shields.io/badge/NVIDIA-%25?logo=nvidia&labelColor=white" height="17" align="texttop"/> <img src="https://img.shields.io/github/stars/NVIDIA/NeMo-Agent-Toolkit?style=social" height="17" align="texttop"/> [NeMo-Agent-Toolkit](https://github.com/NVIDIA/NeMo-Agent-Toolkit) - an open-source library for efficiently connecting and optimizing teams of AI agents
 - <img src="https://img.shields.io/github/stars/deepsense-ai/ragbits?style=social" height="17" align="texttop"/> [ragbits](https://github.com/deepsense-ai/ragbits) - building blocks for rapid development of GenAI applications
+- <img src="https://img.shields.io/github/stars/ahwurm/localharness?style=social" height="17" align="texttop"/> [localharness](https://github.com/ahwurm/localharness) - model-agnostic hierarchical agent harness for local LLMs; define agents in YAML and run them against any OpenAI-compatible endpoint (vLLM, Ollama, LM Studio, llama.cpp)
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Adds **localharness** to **Tools → Agent Frameworks**.

An open-source (MIT) model-agnostic agent harness for local LLMs: define agents in YAML and run them as a hierarchy against any OpenAI-compatible local endpoint (vLLM, Ollama, LM Studio, llama.cpp). It's the agent layer that runs on top of your inference engine, not another engine — squarely in scope for a list about running LLMs locally.

Repo: https://github.com/ahwurm/localharness

Entry follows the section format (stars badge + name + concise description, no trailing period). Thanks!