### PR TITLE
Add mlx-serve to Inference engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/brontoguana/krasis?style=social" height="17" align="texttop"/> [krasis](https://github.com/brontoguana/krasis) - a Hybrid LLM runtime which focuses on efficient running of larger models on consumer grade VRAM limited hardware
 - <img src="https://img.shields.io/github/stars/nlzy/vllm-gfx906?style=social" height="17" align="texttop"/> [vllm-gfx906](https://github.com/nlzy/vllm-gfx906) - vLLM for AMD gfx906 GPUs, e.g. Radeon VII / MI50 / MI60
 - <img src="https://img.shields.io/github/stars/intel/llm-scaler?style=social" height="17" align="texttop"/> [llm-scaler](https://github.com/intel/llm-scaler) - run LLMs on Intel Arc™ Pro B60 GPUs
+- <img src="https://img.shields.io/github/stars/ddalcu/mlx-serve?style=social" height="17" align="texttop"/> [mlx-serve](https://github.com/ddalcu/mlx-serve) - native LLM inference server for Apple Silicon (MLX + GGUF) with OpenAI- and Anthropic-compatible APIs
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Adds [mlx-serve](https://github.com/ddalcu/mlx-serve) to **Inference engines**.

A native **Apple-Silicon** LLM inference server written in Zig: runs MLX-format models *and* GGUF (embedded llama.cpp), exposes **OpenAI- and Anthropic-compatible** APIs (works with Claude Code), with speculative decoding and KV-cache quantization. Ships MLX Core, a macOS menu-bar app. Follows the section's star-badge entry format.