### PR TITLE
Add Legal Document Chat (self-hosted local-LLM document chat)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/oobabooga/text-generation-webui?style=social" height="17" align="texttop"/> [Text generation web UI](https://github.com/oobabooga/text-generation-webui) - LLM UI with advanced features, easy setup, and multiple backend support
 - <img src="https://img.shields.io/github/stars/SillyTavern/SillyTavern?style=social" height="17" align="texttop"/> [SillyTavern](https://github.com/SillyTavern/SillyTavern) - LLM Frontend for Power Users
 - <img src="https://img.shields.io/github/stars/n4ze3m/page-assist?style=social" height="17" align="texttop"/> [Page Assist](https://github.com/n4ze3m/page-assist) - Use your locally running AI models to assist you in your web browsing
+- <img src="https://img.shields.io/github/stars/janderswag/legal-document-chat?style=social" height="17" align="texttop"/> [Legal Document Chat](https://github.com/janderswag/legal-document-chat) - self-hosted UI to chat with your documents using local Ollama models (qwen3 + bge-m3), with page/span citations verified against the source; runs fully offline
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Adds **[Legal Document Chat](https://github.com/janderswag/legal-document-chat)** to **User Interfaces**.

A self-hosted UI to chat with your own documents using **local Ollama models** (`qwen3:14b` + `bge-m3`), with page/span citations mechanically verified against the source. Runs fully offline — loopback-only, no cloud calls, no API keys. Stack: FastAPI + LanceDB. MIT.

- Star-badge entry format per the existing section.
- Working link, MIT-licensed, active repo.