### PR TITLE
Add reactive-agents to Agent Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/badboysm890/ClaraVerse?style=social" height="17" align="texttop"/> [ClaraVerse](https://github.com/badboysm890/ClaraVerse) - privacy-first, fully local AI workspace with Ollama LLM chat, tool calling, agent builder, Stable Diffusion, and embedded n8n-style automation
 - <img src="https://img.shields.io/badge/NVIDIA-%25?logo=nvidia&labelColor=white" height="17" align="texttop"/> <img src="https://img.shields.io/github/stars/NVIDIA/NeMo-Agent-Toolkit?style=social" height="17" align="texttop"/> [NeMo-Agent-Toolkit](https://github.com/NVIDIA/NeMo-Agent-Toolkit) - an open-source library for efficiently connecting and optimizing teams of AI agents
 - <img src="https://img.shields.io/github/stars/deepsense-ai/ragbits?style=social" height="17" align="texttop"/> [ragbits](https://github.com/deepsense-ai/ragbits) - building blocks for rapid development of GenAI applications
+- <img src="https://img.shields.io/github/stars/tylerjrbuell/reactive-agents-ts?style=social" height="17" align="texttop"/> [reactive-agents](https://github.com/tylerjrbuell/reactive-agents-ts) - type-safe TypeScript agent framework on Effect-TS; runs the same code on local Ollama (4B+) and frontier APIs, MCP-native with A2A multi-agent
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Adds Reactive Agents — a type-safe TypeScript AI agent framework built on Effect-TS. Strong fit for this list: the same agent code runs on local Ollama (4B+) models and frontier APIs, with model-adaptive context profiles and tool-call healing that make small local models usable in an agent loop. MCP-native, A2A multi-agent, MIT.

https://github.com/tylerjrbuell/reactive-agents-ts