### PR TITLE
Add ModelPriceWatch to Explorers, Benchmarks, Leaderboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 
 ### Explorers, Benchmarks, Leaderboards
 
+- [ModelPriceWatch](https://modelpricewatch.com/?utm_source=awesome-local-llm&utm_medium=readme&utm_campaign=rafska-local-llm) - track and compare live input/output API prices across 150+ LLM APIs and 24 providers, for the hosted-vs-local cost decision
 - [Arena](https://arena.ai/) - benchmark & compare the best AI models
 - [AI Models & API Providers Analysis](https://artificialanalysis.ai/) - understand the AI landscape to choose the best model and provider for your use case
 - [SWE-rebench](https://swe-rebench.com/) - a continuously evolving and decontaminated benchmark for software engineering LLMs

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 
 ### Explorers, Benchmarks, Leaderboards
 
-- [ModelPriceWatch](https://modelpricewatch.com/?utm_source=awesome-local-llm&utm_medium=readme&utm_campaign=rafska-local-llm) - track and compare live input/output API prices across 150+ LLM APIs and 24 providers, for the hosted-vs-local cost decision
+- [ModelPriceWatch](https://modelpricewatch.com/) - track and compare live input/output API prices across 150+ LLM APIs and 24 providers, for the hosted-vs-local cost decision
 - [Arena](https://arena.ai/) - benchmark & compare the best AI models
 - [AI Models & API Providers Analysis](https://artificialanalysis.ai/) - understand the AI landscape to choose the best model and provider for your use case
 - [SWE-rebench](https://swe-rebench.com/) - a continuously evolving and decontaminated benchmark for software engineering LLMs


### PR DESCRIPTION
Hi — thanks for maintaining Awesome-local-LLM; the hosted-vs-local breakdown is genuinely useful.

**Disclosure:** I maintain ModelPriceWatch, so this adds a project I'm affiliated with — flagging per self-promotion norms. Happy to decline, move, or reword.

The **Explorers, Benchmarks, Leaderboards** section already lists Artificial Analysis and Arena for comparing models/providers. [ModelPriceWatch](https://modelpricewatch.com) is the cost counterpart — it tracks live input/output API prices across 150+ LLM APIs and 24 providers and auto-updates from provider pricing pages, which helps with the hosted-API-vs-run-it-locally cost call.

Added one entry under that section, matching the list's `[name](url) - description` format. Followed CONTRIBUTING.md (fork → branch → README edit → PR).
