### PR TITLE
Add modelfit to Tools > Models

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 ### Models
 
 - <img src="https://img.shields.io/github/stars/AlexsJones/llmfit?style=social" height="17" align="texttop"/> [llmfit](https://github.com/AlexsJones/llmfit) - hundreds of models & providers, one command to find what runs on your hardware
+- <img src="https://img.shields.io/github/stars/Wecko-ai/modelfit?style=social" height="17" align="texttop"/> [modelfit](https://github.com/Wecko-ai/modelfit) - detects your hardware and picks the best local model that fits, plus an open CC BY dataset of model-to-hardware fit
 - <img src="https://img.shields.io/github/stars/dottxt-ai/outlines?style=social" height="17" align="texttop"/> [outlines](https://github.com/dottxt-ai/outlines) - structured outputs for LLMs
 - <img src="https://img.shields.io/github/stars/mostlygeek/llama-swap?style=social" height="17" align="texttop"/> [llama-swap](https://github.com/mostlygeek/llama-swap) - reliable model swapping for any local OpenAI compatible server - llama.cpp, vllm, etc.
 - <img src="https://img.shields.io/github/stars/guidance-ai/llguidance?style=social" height="17" align="texttop"/> [llguidance](https://github.com/guidance-ai/llguidance) - super-fast structured outputs


### PR DESCRIPTION
Adds modelfit, a CLI/site that detects your hardware and recommends the best local model that fits, similar to llmfit but with per-Apple-chip and iPhone support plus an open CC BY 4.0 dataset. Placed alphabetically right after llmfit in Tools > Models.