### PR TITLE
Add llm-speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 
 ### Explorers, Benchmarks, Leaderboards
 
+- [llm-speed](https://llm-speed.com) - crowdsourced, signed and reproducible benchmark of LLM inference speed (tok/s, TTFT, latency) across hosted APIs, consumer GPUs, and Apple Silicon
 - [Arena](https://arena.ai/) - benchmark & compare the best AI models
 - [AI Models & API Providers Analysis](https://artificialanalysis.ai/) - understand the AI landscape to choose the best model and provider for your use case
 - [SWE-rebench](https://swe-rebench.com/) - a continuously evolving and decontaminated benchmark for software engineering LLMs


### PR DESCRIPTION
Hi! Adding [llm-speed](https://llm-speed.com), a crowdsourced benchmark
of how fast LLMs actually run (decode tok/s, TTFT, latency percentiles)
across hosted APIs, consumer GPUs, and Apple Silicon under one
reproducible workload suite (`suite-v1`).

Why it fits this list:
- **Reproducible**: open-source CLI (`pipx install llm-speed`) runs the
  same workload pack on any machine; every published number links
  back to the run record that produced it.
- **Trust chain**: dual-domain SHA-256 sidecar (CDN + GitHub Releases),
  Apache-2.0, public source at github.com/meadow-kun/llm-speed.
- **Open data**: every submission is JWS-signed and queryable via
  `https://api.llm-speed.com/v1/results`.

Following existing format / position. Happy to adjust the blurb or
section if you'd prefer a different fit.
