### PR TITLE
Add Off Grid AI Desktop to User Interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/oobabooga/text-generation-webui?style=social" height="17" align="texttop"/> [Text generation web UI](https://github.com/oobabooga/text-generation-webui) - LLM UI with advanced features, easy setup, and multiple backend support
 - <img src="https://img.shields.io/github/stars/SillyTavern/SillyTavern?style=social" height="17" align="texttop"/> [SillyTavern](https://github.com/SillyTavern/SillyTavern) - LLM Frontend for Power Users
 - <img src="https://img.shields.io/github/stars/n4ze3m/page-assist?style=social" height="17" align="texttop"/> [Page Assist](https://github.com/n4ze3m/page-assist) - Use your locally running AI models to assist you in your web browsing
+- <img src="https://img.shields.io/github/stars/off-grid-ai/off-grid-ai-desktop?style=social" height="17" align="texttop"/> [Off Grid AI Desktop](https://github.com/off-grid-ai/off-grid-ai-desktop) - a private, local-first AI desktop app for macOS (chat, image generation, dictation and personal memory/RAG, fully offline)
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
## What
Adds [Off Grid AI Desktop](https://github.com/off-grid-ai/off-grid-ai-desktop) to **User Interfaces**, alongside Open WebUI, Lobe Chat, and Page Assist.

## About
Open-source (AGPL-3.0) macOS app - a local-first GUI over llama.cpp with on-device image generation, whisper dictation, and personal memory/RAG. Nothing leaves the machine.

Disclosure: I'm involved with the project.