### PR TITLE
Add Tree Ring Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/topoteretes/cognee?style=social" height="17" align="texttop"/> [cognee](https://github.com/topoteretes/cognee) - memory for AI Agents in 5 lines of code
 - <img src="https://img.shields.io/github/stars/LMCache/LMCache?style=social" height="17" align="texttop"/> [LMCache](https://github.com/LMCache/LMCache) - supercharge your LLM with the fastest KV Cache Layer
 - <img src="https://img.shields.io/github/stars/NevaMind-AI/memU?style=social" height="17" align="texttop"/> [memU](https://github.com/NevaMind-AI/memU) - an open-source memory framework for AI companions
+- <img src="https://img.shields.io/github/stars/TerminallyLazy/Tree-Ring-Memory?style=social" height="17" align="texttop"/> [Tree Ring Memory](https://github.com/TerminallyLazy/Tree-Ring-Memory) - Local-first memory lifecycle for AI agents with Rust CLI, SQLite/FTS recall, redaction, forgetting, audit checks, and consolidation.
 - <img src="https://img.shields.io/badge/Google-%234285F4?logo=google&logoColor=red" height="17" align="texttop"/> <img src="https://img.shields.io/github/stars/google-research/reasoning-bank?style=social" height="17" align="texttop"/> [reasoning-bank](https://github.com/google-research/reasoning-bank) - a memory mechanism for agents that learns from both successful and failed trajectories, with reasoning stored as memory content
 
 [Back to Table of Contents](#table-of-contents)


### PR DESCRIPTION
Adds Tree Ring Memory to the `Tools / Memory Management` section.

Why it fits:

- local-first memory lifecycle for AI agents
- Rust CLI with SQLite/FTS recall
- first-class redaction, forgetting, audit checks, and consolidation
- useful for local/private LLM and coding-agent workflows where memory should stay inspectable instead of becoming a transcript dump

Validation:

- checked for existing Tree Ring Memory PRs/issues before submitting
- `git diff --check` passed
- confirmed the README contains one visible Tree Ring Memory entry and one Tree Ring repo URL
- `npx --yes awesome-lint README.md` reports existing repository-wide lint issues; the added Tree Ring row does not appear in the lint output after adjusting casing and punctuation
