### PR TITLE
Add Ghost Vessel to User Interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/oobabooga/text-generation-webui?style=social" height="17" align="texttop"/> [Text generation web UI](https://github.com/oobabooga/text-generation-webui) - LLM UI with advanced features, easy setup, and multiple backend support
 - <img src="https://img.shields.io/github/stars/SillyTavern/SillyTavern?style=social" height="17" align="texttop"/> [SillyTavern](https://github.com/SillyTavern/SillyTavern) - LLM Frontend for Power Users
 - <img src="https://img.shields.io/github/stars/n4ze3m/page-assist?style=social" height="17" align="texttop"/> [Page Assist](https://github.com/n4ze3m/page-assist) - Use your locally running AI models to assist you in your web browsing
+- <img src="https://img.shields.io/github/stars/ghdtjrtka/ghost-vessel?style=social" height="17" align="texttop"/> [Ghost Vessel](https://github.com/ghdtjrtka/ghost-vessel) - Monitor-resident avatar frontend that fronts a local LLM agent (Hermes/OpenClaw) - emotion-beat expressions from pre-rendered clips, persistent mood, local TTS/STT, serves the agent's slash-command menu
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Adds **Ghost Vessel** to *User Interfaces*.

[ghdtjrtka/ghost-vessel](https://github.com/ghdtjrtka/ghost-vessel) is an open-core (MIT) avatar frontend for a **local** LLM agent (Hermes/OpenClaw): the agent's replies drive facial emotion beats played from pre-rendered clips (no runtime GPU for the avatar), with a persistent mood/affinity system, local TTS out (Edge/Qwen3-TTS/MeloTTS/Piper) and VAD + faster-whisper STT in, and the agent's live slash-command menu served in the chat pane.

Followed the section format (star-shield + `[name](link) - description`).