### PR TITLE
Add FitLLM to Hardware section

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/youtube/channel/subscribers/UC8h2Sf-yyo1WXeEUr-OHgyg?style=social" height="17" align="texttop"/> [Miyconst](https://www.youtube.com/@Miyconst) - tests of various types of hardware capable of running LLMs
 - [Kolosal - LLM Memory calculator](https://www.kolosal.ai/memory-calculator) - estimate the RAM requirements of any GGUF model instantly
 - [LLM Inference VRAM & GPU Requirement Calculator](https://app.linpp2009.com/en/llm-gpu-memory-calculator) - calculate how many GPUs you need to deploy LLMs
+- <img src="https://img.shields.io/github/stars/click6067-ship-it/fitllm-engine?style=social" height="17" align="texttop"/> [FitLLM](https://fitllm.run) - architecture-aware "will it fit?" calculator for GPUs and Apple Silicon (MLA, sliding-window and hybrid attention modeled per layer); open MIT engine with `npx fitllm` CLI
 - <img src="https://img.shields.io/github/stars/vosen/ZLUDA?style=social" height="17" align="texttop"/> [ZLUDA](https://github.com/vosen/ZLUDA) - CUDA on non-NVIDIA GPUs
 - [Strix Halo AI Toolboxes](https://strix-halo-toolboxes.com/) - toolboxes for GenAI on AMD Ryzen AI MAX+: containerized environments for LLMs, Image Generation, and Fine-tuning
 - [Strix Halo Wiki](https://strixhalo.wiki/) - a website to gather important information and practical guides for systems powered by AMD Ryzen AI MAX and MAX+ processors


### PR DESCRIPTION
Adds [FitLLM](https://fitllm.run) next to the other memory calculators in the Hardware section.

What it is: a "will this LLM fit my GPU / Mac?" calculator whose KV-cache math is architecture-aware — MLA (GLM/DeepSeek family), sliding-window (Gemma/gpt-oss) and hybrid linear attention (Qwen 3.6) are modeled per layer, which naive calculators over-count by up to ~18x.

Why it may earn its place: the calculation engine is a single open MIT file with 14 published conformance vectors (reproducible by hand from official config.json values), plus an `npx fitllm` CLI with exit 0/1 for pre-download guards. Every hardware number is cited to ≥2 independent sources in-code. No ads, no login.

Happy to adjust format/wording to your preference — or feel free to close if it doesn't fit the list's bar.