### PR TITLE
Add localmodel.run to Hardware section

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/youtube/channel/subscribers/UC8h2Sf-yyo1WXeEUr-OHgyg?style=social" height="17" align="texttop"/> [Miyconst](https://www.youtube.com/@Miyconst) - tests of various types of hardware capable of running LLMs
 - [Kolosal - LLM Memory calculator](https://www.kolosal.ai/memory-calculator) - estimate the RAM requirements of any GGUF model instantly
 - [LLM Inference VRAM & GPU Requirement Calculator](https://app.linpp2009.com/en/llm-gpu-memory-calculator) - calculate how many GPUs you need to deploy LLMs
-- [localmodel.run](https://localmodel.run) - estimate RAM/VRAM fit for 153 local models across 40 devices, every spec sourced
+- [localmodel.run](https://localmodel.run) - check whether a local AI model fits your hardware across 40 devices, backed by an open, sourced dataset (CC BY 4.0) of 150+ models with measured GGUF/ONNX sizes and a public API
 - <img src="https://img.shields.io/github/stars/vosen/ZLUDA?style=social" height="17" align="texttop"/> [ZLUDA](https://github.com/vosen/ZLUDA) - CUDA on non-NVIDIA GPUs
 - [Strix Halo AI Toolboxes](https://strix-halo-toolboxes.com/) - toolboxes for GenAI on AMD Ryzen AI MAX+: containerized environments for LLMs, Image Generation, and Fine-tuning
 - [Strix Halo Wiki](https://strixhalo.wiki/) - a website to gather important information and practical guides for systems powered by AMD Ryzen AI MAX and MAX+ processors

--- a/README.md
+++ b/README.md
@@ -438,6 +438,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/youtube/channel/subscribers/UC8h2Sf-yyo1WXeEUr-OHgyg?style=social" height="17" align="texttop"/> [Miyconst](https://www.youtube.com/@Miyconst) - tests of various types of hardware capable of running LLMs
 - [Kolosal - LLM Memory calculator](https://www.kolosal.ai/memory-calculator) - estimate the RAM requirements of any GGUF model instantly
 - [LLM Inference VRAM & GPU Requirement Calculator](https://app.linpp2009.com/en/llm-gpu-memory-calculator) - calculate how many GPUs you need to deploy LLMs
+- [localmodel.run](https://localmodel.run) - estimate RAM/VRAM fit for 153 local models across 40 devices, every spec sourced
 - <img src="https://img.shields.io/github/stars/vosen/ZLUDA?style=social" height="17" align="texttop"/> [ZLUDA](https://github.com/vosen/ZLUDA) - CUDA on non-NVIDIA GPUs
 - [Strix Halo AI Toolboxes](https://strix-halo-toolboxes.com/) - toolboxes for GenAI on AMD Ryzen AI MAX+: containerized environments for LLMs, Image Generation, and Fine-tuning
 - [Strix Halo Wiki](https://strixhalo.wiki/) - a website to gather important information and practical guides for systems powered by AMD Ryzen AI MAX and MAX+ processors


### PR DESCRIPTION
Adds localmodel.run next to the other memory/VRAM fit calculators in the Hardware section.

It answers whether a model fits a specific device rather than a raw GB number: 153 local models across 40 devices (Apple Silicon unified memory, NVIDIA/AMD GPUs, iPhone, Android, CPU-only), a per-quant fit table from Q2_K to FP16, and every figure linked to its source (HuggingFace GGUF repo, Ollama tag, or vendor spec). The formula is public on the methodology page. Free, no account. Code MIT, data CC BY 4.0: https://github.com/ansumanshah/localmodel.run

Live demo as a HuggingFace Space: https://huggingface.co/spaces/ansumanshah/can-i-run-it-locally

Disclosure: I am the author.