### PR TITLE
Add eVi to User Interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/oobabooga/text-generation-webui?style=social" height="17" align="texttop"/> [Text generation web UI](https://github.com/oobabooga/text-generation-webui) - LLM UI with advanced features, easy setup, and multiple backend support
 - <img src="https://img.shields.io/github/stars/SillyTavern/SillyTavern?style=social" height="17" align="texttop"/> [SillyTavern](https://github.com/SillyTavern/SillyTavern) - LLM Frontend for Power Users
 - <img src="https://img.shields.io/github/stars/n4ze3m/page-assist?style=social" height="17" align="texttop"/> [Page Assist](https://github.com/n4ze3m/page-assist) - Use your locally running AI models to assist you in your web browsing
+- <img src="https://img.shields.io/github/stars/evi-assistant/evi-ai?style=social" height="17" align="texttop"/> [eVi](https://github.com/evi-assistant/evi-ai) - Local-first personal AI assistant with CLI, web, and native desktop (Tauri) frontends for Ollama, LM Studio, llama.cpp, and OpenAI-compatible backends
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Adds **eVi** to the User Interfaces section.

eVi is a local-first personal AI assistant with CLI, web, and native desktop (Tauri) frontends. It's a frontend to local backends — Ollama, LM Studio, llama.cpp, or any OpenAI-compatible endpoint — with tools, long-term memory, and MCP support, keeping inference on the user's own hardware.

- Repo: https://github.com/evi-assistant/evi-ai (MIT)
- Website: https://evi-ai.dev

Matches the section's format (shields star badge + link + single-phrase description). Appended at the bottom since the list is star-ordered. Disclosure: I'm the maintainer of eVi.