### PR TITLE
Add LocalMode to Inference engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/brontoguana/krasis?style=social" height="17" align="texttop"/> [krasis](https://github.com/brontoguana/krasis) - a Hybrid LLM runtime which focuses on efficient running of larger models on consumer grade VRAM limited hardware
 - <img src="https://img.shields.io/github/stars/nlzy/vllm-gfx906?style=social" height="17" align="texttop"/> [vllm-gfx906](https://github.com/nlzy/vllm-gfx906) - vLLM for AMD gfx906 GPUs, e.g. Radeon VII / MI50 / MI60
 - <img src="https://img.shields.io/github/stars/intel/llm-scaler?style=social" height="17" align="texttop"/> [llm-scaler](https://github.com/intel/llm-scaler) - run LLMs on Intel Arc™ Pro B60 GPUs
+- <img src="https://img.shields.io/github/stars/LocalMode-AI/LocalMode?style=social" height="17" align="texttop"/> [LocalMode](https://github.com/LocalMode-AI/LocalMode) - run LLMs, embeddings and RAG entirely in the browser (wraps Transformers.js, WebLLM, wllama), no servers or API keys
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
This PR adds **LocalMode** to the **Inference engines** section.

LocalMode is an open-source (MIT) toolkit that runs LLMs, embeddings, and RAG entirely in the browser, with no servers and no API keys. It wraps browser inference engines (Transformers.js, WebLLM, wllama/GGUF, LiteRT, MediaPipe) behind one interface, alongside a zero-dependency core for vector search, RAG, and agents.

- Repo: https://github.com/LocalMode-AI/LocalMode
- Docs: https://localmode.dev
- Live demos (run in your browser): https://localmode.ai/blocks

Added at the end of the Inference engines list in append order, matching the existing entry format (stars badge, link, lowercase description).
