### PR TITLE
Add Litehouse to Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/langchain-ai/local-deep-researcher?style=social" height="17" align="texttop"/> [local-deep-researcher](https://github.com/langchain-ai/local-deep-researcher) - fully local web research and report writing assistant
 - <img src="https://img.shields.io/github/stars/LearningCircuit/local-deep-research?style=social" height="17" align="texttop"/> [local-deep-research](https://github.com/LearningCircuit/local-deep-research) - an AI-powered research assistant for deep, iterative research
 - <img src="https://img.shields.io/github/stars/murtaza-nasir/maestro?style=social" height="17" align="texttop"/> [maestro](https://github.com/murtaza-nasir/maestro) - an AI-powered research application designed to streamline complex research tasks
+- <img src="https://img.shields.io/github/stars/tunabirgun/litehouse?style=social" height="17" align="texttop"/> [Litehouse](https://github.com/tunabirgun/litehouse) - a browser-only literature-review assistant that retrieves from open scholarly APIs and writes an evidence-locked, cited synthesis with a local WebGPU model, entirely in the browser
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Adds **Litehouse** to the **Tools → Research** section, alongside gpt-researcher / local-deep-researcher / open-notebook.

Litehouse is a browser-only literature-review assistant: it retrieves works from open scholarly APIs (OpenAlex, Crossref, Europe PMC, DataCite) and writes an evidence-locked, cited synthesis with a **local WebGPU model (Qwen3 via web-llm/MLC)** — the model, storage, and rendering all run in the browser with no server. It fits this list as a local-LLM research tool.

Repo: https://github.com/tunabirgun/litehouse · Live: https://tunabirgun.github.io/litehouse/

Disclosure: I'm the author.