### PR TITLE
Add Alyxx Engine to Inference engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/brontoguana/krasis?style=social" height="17" align="texttop"/> [krasis](https://github.com/brontoguana/krasis) - a Hybrid LLM runtime which focuses on efficient running of larger models on consumer grade VRAM limited hardware
 - <img src="https://img.shields.io/github/stars/nlzy/vllm-gfx906?style=social" height="17" align="texttop"/> [vllm-gfx906](https://github.com/nlzy/vllm-gfx906) - vLLM for AMD gfx906 GPUs, e.g. Radeon VII / MI50 / MI60
 - <img src="https://img.shields.io/github/stars/intel/llm-scaler?style=social" height="17" align="texttop"/> [llm-scaler](https://github.com/intel/llm-scaler) - run LLMs on Intel Arc™ Pro B60 GPUs
+- <img src="https://img.shields.io/github/stars/Alejandro-GDL/Alyxx-Engine?style=social" height="17" align="texttop"/> [Alyxx Engine](https://github.com/Alejandro-GDL/Alyxx-Engine) - run giant mixture-of-experts models on a 16 GB consumer GPU losslessly, streaming experts off disk
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Adds **Alyxx Engine** to Inference engines.

Lossless streaming inference for giant MoE LLMs on a 16 GB consumer GPU — it streams the routed experts off disk and keeps the hot ones resident, and ships a verifier so the lossless claim is reproducible on your own machine.

Repo: https://github.com/Alejandro-GDL/Alyxx-Engine
