### PR TITLE
Add Lokale KI (German local-LLM guide) to Hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/vosen/ZLUDA?style=social" height="17" align="texttop"/> [ZLUDA](https://github.com/vosen/ZLUDA) - CUDA on non-NVIDIA GPUs
 - [Strix Halo AI Toolboxes](https://strix-halo-toolboxes.com/) - toolboxes for GenAI on AMD Ryzen AI MAX+: containerized environments for LLMs, Image Generation, and Fine-tuning
 - [Strix Halo Wiki](https://strixhalo.wiki/) - a website to gather important information and practical guides for systems powered by AMD Ryzen AI MAX and MAX+ processors
+- [Lokale KI](https://i6eal.de/lokale-ki/) - German-language guide to running LLMs locally: hardware requirements and model recommendations
 - <img src="https://img.shields.io/github/stars/paudley/ai-notes?style=social" height="17" align="texttop"/> [ai-notes](https://github.com/paudley/ai-notes) - random AI notes for working with local models or playing around with random machine learning bits
 
 [Back to Table of Contents](#table-of-contents)


### PR DESCRIPTION
Adds Lokale KI, a German-language guide to running LLMs locally (hardware requirements and model recommendations), to the Hardware section next to the other website resources.

Disclosure: I maintain this guide.