### PR TITLE
Add VerdictBits LLM VRAM Calculator (Hardware)

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/youtube/channel/subscribers/UC8h2Sf-yyo1WXeEUr-OHgyg?style=social" height="17" align="texttop"/> [Miyconst](https://www.youtube.com/@Miyconst) - tests of various types of hardware capable of running LLMs
 - [Kolosal - LLM Memory calculator](https://www.kolosal.ai/memory-calculator) - estimate the RAM requirements of any GGUF model instantly
 - [LLM Inference VRAM & GPU Requirement Calculator](https://app.linpp2009.com/en/llm-gpu-memory-calculator) - calculate how many GPUs you need to deploy LLMs
-- [Setup Quarterly - LLM VRAM Calculator](https://verdictbits.com/reviews/llm-vram-calculator/) - enter model size, quantization and context length to see the VRAM needed and which GPUs fit
+- [VerdictBits LLM VRAM Calculator](https://verdictbits.com/reviews/llm-vram-calculator/) - enter model size, quantization and context length to see the VRAM needed and which GPUs fit
 - <img src="https://img.shields.io/github/stars/vosen/ZLUDA?style=social" height="17" align="texttop"/> [ZLUDA](https://github.com/vosen/ZLUDA) - CUDA on non-NVIDIA GPUs
 - [Strix Halo AI Toolboxes](https://strix-halo-toolboxes.com/) - toolboxes for GenAI on AMD Ryzen AI MAX+: containerized environments for LLMs, Image Generation, and Fine-tuning
 - [Strix Halo Wiki](https://strixhalo.wiki/) - a website to gather important information and practical guides for systems powered by AMD Ryzen AI MAX and MAX+ processors

--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/youtube/channel/subscribers/UC8h2Sf-yyo1WXeEUr-OHgyg?style=social" height="17" align="texttop"/> [Miyconst](https://www.youtube.com/@Miyconst) - tests of various types of hardware capable of running LLMs
 - [Kolosal - LLM Memory calculator](https://www.kolosal.ai/memory-calculator) - estimate the RAM requirements of any GGUF model instantly
 - [LLM Inference VRAM & GPU Requirement Calculator](https://app.linpp2009.com/en/llm-gpu-memory-calculator) - calculate how many GPUs you need to deploy LLMs
-- [Setup Quarterly - LLM VRAM Calculator](https://setupquarterly.com/reviews/llm-vram-calculator/) - enter model size, quantization and context length to see the VRAM needed and which GPUs fit
+- [Setup Quarterly - LLM VRAM Calculator](https://verdictbits.com/reviews/llm-vram-calculator/) - enter model size, quantization and context length to see the VRAM needed and which GPUs fit
 - <img src="https://img.shields.io/github/stars/vosen/ZLUDA?style=social" height="17" align="texttop"/> [ZLUDA](https://github.com/vosen/ZLUDA) - CUDA on non-NVIDIA GPUs
 - [Strix Halo AI Toolboxes](https://strix-halo-toolboxes.com/) - toolboxes for GenAI on AMD Ryzen AI MAX+: containerized environments for LLMs, Image Generation, and Fine-tuning
 - [Strix Halo Wiki](https://strixhalo.wiki/) - a website to gather important information and practical guides for systems powered by AMD Ryzen AI MAX and MAX+ processors

--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/youtube/channel/subscribers/UC8h2Sf-yyo1WXeEUr-OHgyg?style=social" height="17" align="texttop"/> [Miyconst](https://www.youtube.com/@Miyconst) - tests of various types of hardware capable of running LLMs
 - [Kolosal - LLM Memory calculator](https://www.kolosal.ai/memory-calculator) - estimate the RAM requirements of any GGUF model instantly
 - [LLM Inference VRAM & GPU Requirement Calculator](https://app.linpp2009.com/en/llm-gpu-memory-calculator) - calculate how many GPUs you need to deploy LLMs
+- [Setup Quarterly - LLM VRAM Calculator](https://setupquarterly.com/reviews/llm-vram-calculator/) - enter model size, quantization and context length to see the VRAM needed and which GPUs fit
 - <img src="https://img.shields.io/github/stars/vosen/ZLUDA?style=social" height="17" align="texttop"/> [ZLUDA](https://github.com/vosen/ZLUDA) - CUDA on non-NVIDIA GPUs
 - [Strix Halo AI Toolboxes](https://strix-halo-toolboxes.com/) - toolboxes for GenAI on AMD Ryzen AI MAX+: containerized environments for LLMs, Image Generation, and Fine-tuning
 - [Strix Halo Wiki](https://strixhalo.wiki/) - a website to gather important information and practical guides for systems powered by AMD Ryzen AI MAX and MAX+ processors


### PR DESCRIPTION
Adds a free, no-signup **LLM VRAM calculator** to the Hardware section, alongside the existing Kolosal and linpp2009 calculators. Enter a model size, quantization and context length and it returns the VRAM / unified memory needed to run the model locally and which GPUs fit — no account, no paywall.

https://verdictbits.com/reviews/llm-vram-calculator/

Placed in Hardware next to the other memory/VRAM calculators. Happy to adjust the wording or placement to match the list's conventions.
