### PR TITLE
Add Bodega One Code to Coding Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/humanlayer/humanlayer?style=social" height="17" align="texttop"/> [humanlayer](https://github.com/humanlayer/humanlayer) - the best way to get AI coding agents to solve hard problems in complex codebases
 - <img src="https://img.shields.io/github/stars/ThePrimeagen/99?style=social" height="17" align="texttop"/> [99](https://github.com/ThePrimeagen/99) - neovim AI agent done right
 - <img src="https://img.shields.io/github/stars/carlrobertoh/ProxyAI?style=social" height="17" align="texttop"/> [ProxyAI](https://github.com/carlrobertoh/ProxyAI) - the leading open-source AI copilot for JetBrains
+- [Bodega One Code](https://bodegaone.ai) - a local-first AI coding IDE with a built-in agent, bring-your-own-LLM, and offline/air-gap support
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Adds Bodega One Code to the Coding Agents section.

It's a local-first AI coding IDE with a built-in agent, bring-your-own-LLM (offline via Ollama or LM Studio, or 10+ cloud provider presets), and air-gap support so nothing leaves your machine. It's a closed-source product, so the entry uses a website link with no repo star badge, matching the existing closed-source style on the list (e.g. the LM Studio entry). Free to use, documented at https://bodegaone.ai.
