### PR TITLE
Add lucinate: multi-backend terminal AI chat client

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/oobabooga/text-generation-webui?style=social" height="17" align="texttop"/> [Text generation web UI](https://github.com/oobabooga/text-generation-webui) - LLM UI with advanced features, easy setup, and multiple backend support
 - <img src="https://img.shields.io/github/stars/SillyTavern/SillyTavern?style=social" height="17" align="texttop"/> [SillyTavern](https://github.com/SillyTavern/SillyTavern) - LLM Frontend for Power Users
 - <img src="https://img.shields.io/github/stars/n4ze3m/page-assist?style=social" height="17" align="texttop"/> [Page Assist](https://github.com/n4ze3m/page-assist) - Use your locally running AI models to assist you in your web browsing
+- <img src="https://img.shields.io/github/stars/lucinate-ai/lucinate?style=social" height="17" align="texttop"/> [lucinate](https://github.com/lucinate-ai/lucinate) - A multi-backend terminal AI chat client for OpenClaw, Hermes, Ollama, and OpenAI-compatible APIs
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
### Add [lucinate](https://github.com/lucinate-ai/lucinate)

A terminal-native AI chat client that supports OpenClaw, Hermes Agent, Ollama, and any OpenAI-compatible backend — with routines, multi-agent switching, and streaming responses, all in the TUI.

**Why it fits:** lucinate is a user interface for local LLMs — it connects to Ollama, vLLM, LM Studio, and other local backends, making it a natural fit alongside the other tools in the User Interfaces section. It supports multiple backends and features reusable prompt routines, tool call cards, and local agent skills.

**Contribution guidelines followed:**
- Added to the bottom of the User Interfaces section
- Uses the established badge format ([lucinate-ai/lucinate](https://img.shields.io/github/stars/lucinate-ai/lucinate?style=social))
- Open source (Apache 2.0), actively maintained