### PR TITLE
Add SwarmDo-A1 to Coding models

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - [OmniCoder-9B](https://huggingface.co/Tesslate/OmniCoder-9B) - a 9-billion parameter coding agent model built by Tesslate, fine-tuned on top of Qwen3.5-9B's hybrid architecture
 - [NousCoder-14B](https://huggingface.co/NousResearch/NousCoder-14B) - a competitive programming model post-trained on Qwen3-14B via reinforcement learning
 - [MusaCoder-27B](https://huggingface.co/MooreThreads/MusaCoder-27B) - a code model developed by Moore Threads for PyTorch-to-CUDA/MUSA native kernel generation
+- [SwarmDo-A1](https://huggingface.co/SwarmDo/SwarmDo-A1) - an open, self-hostable multimodal coding model, shipped as a LoRA adapter on Qwen3.6-27B, that verifies patches by executing the project's tests
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
This PR adds one entry to **Large Language Models → Specific models → Coding**.

**Entry:** [SwarmDo-A1](https://huggingface.co/SwarmDo/SwarmDo-A1) — an open, self-hostable multimodal coding model, shipped as a LoRA adapter on Qwen3.6-27B (Apache-2.0), that verifies patches by executing the project's tests.

**Why it fits this list:** it's an open-weight, self-hostable coding model (like OmniCoder-9B / NousCoder-14B already listed) and runs locally on a single 80GB GPU via vLLM. Weights are on Hugging Face under Apache-2.0.

I followed the existing format (name linked to the Hugging Face page, short lowercase description) and only added a single line at the end of the Coding section — no other content changed.