### PR TITLE
Add Agentlas OS to Agent Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/badboysm890/ClaraVerse?style=social" height="17" align="texttop"/> [ClaraVerse](https://github.com/badboysm890/ClaraVerse) - privacy-first, fully local AI workspace with Ollama LLM chat, tool calling, agent builder, Stable Diffusion, and embedded n8n-style automation
 - <img src="https://img.shields.io/badge/NVIDIA-%25?logo=nvidia&labelColor=white" height="17" align="texttop"/> <img src="https://img.shields.io/github/stars/NVIDIA/NeMo-Agent-Toolkit?style=social" height="17" align="texttop"/> [NeMo-Agent-Toolkit](https://github.com/NVIDIA/NeMo-Agent-Toolkit) - an open-source library for efficiently connecting and optimizing teams of AI agents
 - <img src="https://img.shields.io/github/stars/deepsense-ai/ragbits?style=social" height="17" align="texttop"/> [ragbits](https://github.com/deepsense-ai/ragbits) - building blocks for rapid development of GenAI applications
+- <img src="https://img.shields.io/github/stars/agentlas-ai/Agentlas-OS?style=social" height="17" align="texttop"/> [Agentlas OS](https://github.com/agentlas-ai/Agentlas-OS) - a local-first, model-agnostic Agent Operation Environment (AOE) for building, routing, and verifying specialist agents and teams across local models and supported LLM hosts
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
## Summary

- Add Agentlas OS to the Agent Frameworks section.
- Use the list's existing GitHub stars badge and one-line description format.
- Describe its local-first, model-agnostic Agent Operation Environment (AOE) scope.

## Verification

- The repository link and stars badge target resolve.
- The entry is placed at the bottom of the appropriate section.
- `git diff --check` passes.

Disclosure: I am submitting this on behalf of Agentlas.
