### PR TITLE
Add Logue to User Interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/oobabooga/text-generation-webui?style=social" height="17" align="texttop"/> [Text generation web UI](https://github.com/oobabooga/text-generation-webui) - LLM UI with advanced features, easy setup, and multiple backend support
 - <img src="https://img.shields.io/github/stars/SillyTavern/SillyTavern?style=social" height="17" align="texttop"/> [SillyTavern](https://github.com/SillyTavern/SillyTavern) - LLM Frontend for Power Users
 - <img src="https://img.shields.io/github/stars/n4ze3m/page-assist?style=social" height="17" align="texttop"/> [Page Assist](https://github.com/n4ze3m/page-assist) - Use your locally running AI models to assist you in your web browsing
+- <img src="https://img.shields.io/github/stars/bitwize-ai/Logue?style=social" height="17" align="texttop"/> [Logue](https://github.com/bitwize-ai/Logue) - Privacy-first macOS app for AI meeting notes and writing; on-device transcription, speaker diarization, and a local LLM (MLX) writing assistant — everything runs locally
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Adds **[Logue](https://github.com/bitwize-ai/Logue)** under **User Interfaces**, following the existing stars-badge format.

Logue is a privacy-first macOS app for AI meeting notes and writing. It runs a local LLM (via Apple **MLX**) plus on-device transcription and speaker diarization — a genuine local-LLM end-user UI. Open source (MIT).