### PR TITLE
Add Xybrid to inference engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/brontoguana/krasis?style=social" height="17" align="texttop"/> [krasis](https://github.com/brontoguana/krasis) - a Hybrid LLM runtime which focuses on efficient running of larger models on consumer grade VRAM limited hardware
 - <img src="https://img.shields.io/github/stars/nlzy/vllm-gfx906?style=social" height="17" align="texttop"/> [vllm-gfx906](https://github.com/nlzy/vllm-gfx906) - vLLM for AMD gfx906 GPUs, e.g. Radeon VII / MI50 / MI60
 - <img src="https://img.shields.io/github/stars/intel/llm-scaler?style=social" height="17" align="texttop"/> [llm-scaler](https://github.com/intel/llm-scaler) - run LLMs on Intel Arc™ Pro B60 GPUs
+- <img src="https://img.shields.io/github/stars/xybrid-ai/xybrid?style=social" height="17" align="texttop"/> [Xybrid](https://github.com/xybrid-ai/xybrid) - local-first runtime for running LLMs natively in apps and games
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Adds Xybrid to the Inference engines section. Xybrid is an Apache-2.0, local-first runtime for running LLMs natively in apps and games; the entry follows the section’s existing linked star-badge format.