### PR TITLE
Add whatbroke to Testing, Evaluation and Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/Giskard-AI/giskard?style=social" height="17" align="texttop"/> [giskard](https://github.com/Giskard-AI/giskard) - an open-source evaluation & testing for AI & LLM systems
 - <img src="https://img.shields.io/github/stars/Agenta-AI/agenta?style=social" height="17" align="texttop"/> [agenta](https://github.com/Agenta-AI/agenta) - an open-source LLMOps platform: prompt playground, prompt management, LLM evaluation, and LLM observability all in one place
 - <img src="https://img.shields.io/badge/NVIDIA-%25?logo=nvidia&labelColor=white" height="17" align="texttop"/> <img src="https://img.shields.io/github/stars/NVIDIA-NeMo/evaluator?style=social" height="17" align="texttop"/> [Evaluator](https://github.com/NVIDIA-NeMo/evaluator) - open-source library for scalable, reproducible evaluation of AI models and benchmarks
+- <img src="https://img.shields.io/github/stars/arthi-arumugam-git/whatbroke?style=social" height="17" align="texttop"/> [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) - a CLI that diffs an AI agent's behavior between two runs of the same task: dropped tool calls, drifted arguments, cost and latency changes. Deterministic and fully offline; records local models through a zero-code proxy
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Adding [whatbroke](https://github.com/arthi-arumugam-git/whatbroke), a CLI that diffs an AI agent's behavior between two recorded runs of the same task: dropped tool calls, drifted arguments, cost/latency changes, flipped outputs.

Relevant to this list because it is deterministic and fully local: no accounts, no API keys, no judge model, traces never leave the machine. The included case study was recorded against a local model via Ollama (a 3x smaller model that kept saying 'your subscription is cancelled' while silently dropping the cancellation tool call).

MIT licensed. CLI on npm (whatbroke-cli), Python recorder on PyPI (whatbroke-recorder), importers for OpenTelemetry / Langfuse / LangSmith traces.
