### PR TITLE
Add routefoundry (Testing, Evaluation and Observability)

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/Giskard-AI/giskard?style=social" height="17" align="texttop"/> [giskard](https://github.com/Giskard-AI/giskard) - an open-source evaluation & testing for AI & LLM systems
 - <img src="https://img.shields.io/github/stars/Agenta-AI/agenta?style=social" height="17" align="texttop"/> [agenta](https://github.com/Agenta-AI/agenta) - an open-source LLMOps platform: prompt playground, prompt management, LLM evaluation, and LLM observability all in one place
 - <img src="https://img.shields.io/badge/NVIDIA-%25?logo=nvidia&labelColor=white" height="17" align="texttop"/> <img src="https://img.shields.io/github/stars/NVIDIA-NeMo/evaluator?style=social" height="17" align="texttop"/> [Evaluator](https://github.com/NVIDIA-NeMo/evaluator) - open-source library for scalable, reproducible evaluation of AI models and benchmarks
+- <img src="https://img.shields.io/github/stars/RitikPatill/routefoundry?style=social" height="17" align="texttop"/> [routefoundry](https://github.com/RitikPatill/routefoundry) - benchmark the models already installed in Ollama with a deterministic auto-graded suite (no LLM judge), then audit whether routing between them helps and compile an explainable routing policy
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Adds [routefoundry](https://github.com/RitikPatill/routefoundry), MIT-licensed.

It benchmarks the models you already have installed in Ollama using a 38-task auto-gradable suite graded deterministically (exact number / exact string / JSON field / regex), so there is no LLM judge whose bias would itself need auditing. It then audits whether routing between those models actually helps, and compiles an explainable policy.

Measured example from the repo, with raw rows committed: across 152 generations on a 16 GB laptop, no model won every category. deepseek-r1:1.5b (1.1 GB) answered 10/12 arithmetic word problems where llama3.2:3b (2.0 GB) answered 2/12 - and lost structured extraction 4/9 against 9/9.

Placed alphabetically in Testing, Evaluation and Observability, matching the existing star-badge format. Happy to move it or reword if you'd prefer it elsewhere.