### PR TITLE
Add ANEForge to Inference engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/brontoguana/krasis?style=social" height="17" align="texttop"/> [krasis](https://github.com/brontoguana/krasis) - a Hybrid LLM runtime which focuses on efficient running of larger models on consumer grade VRAM limited hardware
 - <img src="https://img.shields.io/github/stars/nlzy/vllm-gfx906?style=social" height="17" align="texttop"/> [vllm-gfx906](https://github.com/nlzy/vllm-gfx906) - vLLM for AMD gfx906 GPUs, e.g. Radeon VII / MI50 / MI60
 - <img src="https://img.shields.io/github/stars/intel/llm-scaler?style=social" height="17" align="texttop"/> [llm-scaler](https://github.com/intel/llm-scaler) - run LLMs on Intel Arc™ Pro B60 GPUs
+- <img src="https://img.shields.io/github/stars/sbryngelson/ANEForge?style=social" height="17" align="texttop"/> [ANEForge](https://github.com/sbryngelson/ANEForge) - run LLM decode directly on the Apple Neural Engine without CoreML; loads Llama/Qwen models from the Hub
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Adds [ANEForge](https://github.com/sbryngelson/ANEForge) under **Inference engines**.

ANEForge runs LLM decode directly on the Apple Neural Engine (ANE) without CoreML -- it loads Llama/Qwen-family models from the Hugging Face Hub and dispatches the decoder to the engine (e.g. TinyLlama-1.1B at ~62 tok/s on an M5 Pro). It fits alongside the other Apple Silicon engines already listed (mlx-lm, omlx). MIT-licensed, on PyPI, with a paper (arXiv:2606.17090).