### PR TITLE
Add ThoughtDAG to User Interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/oobabooga/text-generation-webui?style=social" height="17" align="texttop"/> [Text generation web UI](https://github.com/oobabooga/text-generation-webui) - LLM UI with advanced features, easy setup, and multiple backend support
 - <img src="https://img.shields.io/github/stars/SillyTavern/SillyTavern?style=social" height="17" align="texttop"/> [SillyTavern](https://github.com/SillyTavern/SillyTavern) - LLM Frontend for Power Users
 - <img src="https://img.shields.io/github/stars/n4ze3m/page-assist?style=social" height="17" align="texttop"/> [Page Assist](https://github.com/n4ze3m/page-assist) - Use your locally running AI models to assist you in your web browsing
+- <img src="https://img.shields.io/github/stars/chenxiachan/thoughtdag?style=social" height="17" align="texttop"/> [ThoughtDAG](https://github.com/chenxiachan/thoughtdag) - Local-first visual LLM workspace where graph edges determine model context, with Ollama support, branching, merging, and document extraction
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
## Summary

Adds ThoughtDAG to the User Interfaces section.

ThoughtDAG is a local-first visual LLM workspace where graph edges determine model context. It supports Ollama and OpenAI-compatible endpoints, branching, merging, and document extraction.

## Why it fits

It is an end-user interface for running local models through Ollama, while preserving explicit, human-controlled context selection.

Disclosure: I maintain ThoughtDAG.