### PR TITLE
Add PostTrainLLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 
 ### Training and Fine-tuning
 
+- <img src="https://img.shields.io/github/stars/PostTrainLLM/posttrainllm?style=social" height="17" align="texttop"/> [PostTrainLLM](https://github.com/PostTrainLLM/posttrainllm) - Mac-local factory for post-training, evaluating, and packaging specialist LLMs
 - <img src="https://img.shields.io/github/stars/p-e-w/heretic?style=social" height="17" align="texttop"/> [heretic](https://github.com/p-e-w/heretic) - fully automatic censorship removal for language models
 - <img src="https://img.shields.io/github/stars/huggingface/sentence-transformers?style=social" height="17" align="texttop"/> [sentence-transformers](https://github.com/huggingface/sentence-transformers) - a Python library for using and training embedding and reranker models for applications like retrieval augmented generation, semantic search, and more
 - <img src="https://img.shields.io/github/stars/huggingface/trl?style=social" height="17" align="texttop"/> [trl](https://github.com/huggingface/trl) - train transformer language models with reinforcement learning


### PR DESCRIPTION
## Add PostTrainLLM

Mac-local open-source factory for post-training and evaluating specialist LLMs (real eval gates, MLX packaging).

- https://github.com/PostTrainLLM/posttrainllm
- https://posttrainllm.com/how-to-train-your-own-llm

Under **Tools → Training and Fine-tuning**.