### PR TITLE
Add Llamaport to User Interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/oobabooga/text-generation-webui?style=social" height="17" align="texttop"/> [Text generation web UI](https://github.com/oobabooga/text-generation-webui) - LLM UI with advanced features, easy setup, and multiple backend support
 - <img src="https://img.shields.io/github/stars/SillyTavern/SillyTavern?style=social" height="17" align="texttop"/> [SillyTavern](https://github.com/SillyTavern/SillyTavern) - LLM Frontend for Power Users
 - <img src="https://img.shields.io/github/stars/n4ze3m/page-assist?style=social" height="17" align="texttop"/> [Page Assist](https://github.com/n4ze3m/page-assist) - Use your locally running AI models to assist you in your web browsing
+- <img src="https://img.shields.io/github/stars/smkamranqadri/llamaport?style=social" height="17" align="texttop"/> [Llamaport](https://github.com/smkamranqadri/llamaport) - macOS GUI for llama-server with header-accurate model info, visible launch commands, live token rates and resumable Hugging Face downloads
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Adds [Llamaport](https://github.com/smkamranqadri/llamaport), an open-source macOS GUI for `llama-server`.

It reads GGUF headers directly, so quantisation, context length and MoE structure come from the file rather than the filename. The full launch command is shown before a model starts, and while it serves the app reports KV cache, generation and prompt-eval rates, memory pressure and swap. Downloads from Hugging Face use ranged segments, resume after a kill, verify sha256 and queue.

It deliberately has no chat interface of its own — a running model opens llama.cpp's own web UI in a second window — so it sits alongside the chat frontends here rather than competing with them.

Rust and Tauri, MIT. Disclosure: I am the author.