### PR TITLE
Add AMD Strix Halo local LLM guide to Hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/vosen/ZLUDA?style=social" height="17" align="texttop"/> [ZLUDA](https://github.com/vosen/ZLUDA) - CUDA on non-NVIDIA GPUs
 - [Strix Halo AI Toolboxes](https://strix-halo-toolboxes.com/) - toolboxes for GenAI on AMD Ryzen AI MAX+: containerized environments for LLMs, Image Generation, and Fine-tuning
 - [Strix Halo Wiki](https://strixhalo.wiki/) - a website to gather important information and practical guides for systems powered by AMD Ryzen AI MAX and MAX+ processors
+- <img src="https://img.shields.io/github/stars/hogeheer499-commits/strix-halo-guide?style=social" height="17" align="texttop"/> [AMD Strix Halo Local LLM Guide](https://github.com/hogeheer499-commits/strix-halo-guide) - copyable Ryzen AI MAX+ 395 setup with Vulkan/RADV and ROCm routes, reproducible benchmarks, raw logs, failed paths, and cross-system evidence
 - <img src="https://img.shields.io/github/stars/paudley/ai-notes?style=social" height="17" align="texttop"/> [ai-notes](https://github.com/paudley/ai-notes) - random AI notes for working with local models or playing around with random machine learning bits
 
 [Back to Table of Contents](#table-of-contents)


### PR DESCRIPTION
Adds the AMD Strix Halo Local LLM Guide to the existing Hardware section.

It complements the two adjacent Strix Halo resources rather than replacing them:

- Toolboxes: packaged runtime environments
- Wiki: broad platform information and practical references
- This guide: copyable Ryzen AI MAX+ 395 setup, reproducible direct/server benchmarks, Vulkan/RADV and ROCm routes, raw logs, failed paths, and cross-system evidence

The branch is rebased onto the current `main`, and the entry follows the section's existing GitHub-stars badge style.

This supersedes #91, which I previously closed myself.
