### PR TITLE
Add Open Index to memory management

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/topoteretes/cognee?style=social" height="17" align="texttop"/> [cognee](https://github.com/topoteretes/cognee) - memory for AI Agents in 5 lines of code
 - <img src="https://img.shields.io/github/stars/LMCache/LMCache?style=social" height="17" align="texttop"/> [LMCache](https://github.com/LMCache/LMCache) - supercharge your LLM with the fastest KV Cache Layer
 - <img src="https://img.shields.io/github/stars/NevaMind-AI/memU?style=social" height="17" align="texttop"/> [memU](https://github.com/NevaMind-AI/memU) - an open-source memory framework for AI companions
+- <img src="https://img.shields.io/github/stars/DrDroidLab/open-index?style=social" height="17" align="texttop"/> [Open Index](https://github.com/DrDroidLab/open-index) - local structured context graphs with hybrid search and read/write MCP access for domain-specific agents
 - <img src="https://img.shields.io/badge/Google-%234285F4?logo=google&logoColor=red" height="17" align="texttop"/> <img src="https://img.shields.io/github/stars/google-research/reasoning-bank?style=social" height="17" align="texttop"/> [reasoning-bank](https://github.com/google-research/reasoning-bank) - a memory mechanism for agents that learns from both successful and failed trajectories, with reasoning stored as memory content
 
 [Back to Table of Contents](#table-of-contents)


### PR DESCRIPTION
## Summary

Adds Open Index under **Tools → Memory Management**.

Open Index fits the local-LLM scope because its default SQLite backend runs locally, semantic embeddings are optional, and its MCP server can be launched over stdio without a hosted dependency. The entry matches the section's badge and description format.

Project: https://github.com/DrDroidLab/open-index

Disclosure: this is an affiliated submission from the Open Index team.