### PR TITLE
Add memcode to Coding Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/Kilo-Org/kilocode?style=social" height="17" align="texttop"/> [kilocode](https://github.com/Kilo-Org/kilocode) - open source AI coding assistant for planning, building, and fixing code
 - <img src="https://img.shields.io/github/stars/humanlayer/humanlayer?style=social" height="17" align="texttop"/> [humanlayer](https://github.com/humanlayer/humanlayer) - the best way to get AI coding agents to solve hard problems in complex codebases
 - <img src="https://img.shields.io/github/stars/ThePrimeagen/99?style=social" height="17" align="texttop"/> [99](https://github.com/ThePrimeagen/99) - neovim AI agent done right
+- <img src="https://img.shields.io/github/stars/memcode-ai/memcode?style=social" height="17" align="texttop"/> [memcode](https://github.com/memcode-ai/memcode) - a terminal coding agent that remembers your repo (persistent per-project memory in a local .memcode store); single Go binary, runs against a local Ollama endpoint or your own keys
 - <img src="https://img.shields.io/github/stars/carlrobertoh/ProxyAI?style=social" height="17" align="texttop"/> [ProxyAI](https://github.com/carlrobertoh/ProxyAI) - the leading open-source AI copilot for JetBrains
 
 [Back to Table of Contents](#table-of-contents)


### PR DESCRIPTION
Adds **memcode** to Coding Agents (with the stars-badge format).

A terminal coding agent that remembers your repo: persistent per-project memory in a local `.memcode` store. Single Go binary; runs against a local Ollama endpoint (or your own keys / a hosted gateway). Self-hostable, MIT.

Repo: https://github.com/memcode-ai/memcode