### PR TITLE
Add Atomic Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/humanlayer/humanlayer?style=social" height="17" align="texttop"/> [humanlayer](https://github.com/humanlayer/humanlayer) - the best way to get AI coding agents to solve hard problems in complex codebases
 - <img src="https://img.shields.io/github/stars/ThePrimeagen/99?style=social" height="17" align="texttop"/> [99](https://github.com/ThePrimeagen/99) - neovim AI agent done right
 - <img src="https://img.shields.io/github/stars/carlrobertoh/ProxyAI?style=social" height="17" align="texttop"/> [ProxyAI](https://github.com/carlrobertoh/ProxyAI) - the leading open-source AI copilot for JetBrains
+- <img src="https://img.shields.io/github/stars/AtomicBot-ai/atomic-agent?style=social" height="17" align="texttop"/> [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent) - a local-first CLI and TUI coding agent that runs open-weight models entirely on your machine via a llama.cpp fork, with 56 tools, MCP support and a 5-layer memory, and no account or API key to install
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Hi, and thanks for maintaining this list! I'm the CPO of Atomic Agent, and this list is exactly where our users already live, so I'd love to join it.

Atomic Agent is a local-first coding and agentic assistant. It runs open-weight models entirely on your machine through a llama.cpp fork, so you can code with an agent without an account, an API key, or your code going to someone else's server. It ships as both a CLI and a TUI, brings 56 tools (browser, filesystem, git, memory, vision), speaks MCP, and keeps a 5-layer local memory. Works on macOS, Linux and Windows.

I added one entry to the **Coding Agents** section, next to the other local-model agents like aider, cline and goose.

A few extra links in case they're useful:
- Repo: https://github.com/AtomicBot-ai/atomic-agent (MIT)
- Site: https://atomicagent.io
- Install: `curl -fsSL https://atomicagent.io/install | sh`
- Docs: https://atomicagent.io/docs
- X: https://x.com/atomicagent_io
- Discord: https://discord.gg/Us7qXtDGw

Happy to tweak the wording or placement if you'd prefer something different. Thanks for considering it!
