### PR TITLE
Add Lians to Memory Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/LMCache/LMCache?style=social" height="17" align="texttop"/> [LMCache](https://github.com/LMCache/LMCache) - supercharge your LLM with the fastest KV Cache Layer
 - <img src="https://img.shields.io/github/stars/NevaMind-AI/memU?style=social" height="17" align="texttop"/> [memU](https://github.com/NevaMind-AI/memU) - an open-source memory framework for AI companions
 - <img src="https://img.shields.io/badge/Google-%234285F4?logo=google&logoColor=red" height="17" align="texttop"/> <img src="https://img.shields.io/github/stars/google-research/reasoning-bank?style=social" height="17" align="texttop"/> [reasoning-bank](https://github.com/google-research/reasoning-bank) - a memory mechanism for agents that learns from both successful and failed trajectories, with reasoning stored as memory content
+- <img src="https://img.shields.io/github/stars/Lians-ai/Lians?style=social" height="17" align="texttop"/> [Lians](https://github.com/Lians-ai/Lians) - local-first memory for any AI agent, with bitemporal history, point-in-time recall, and MCP access
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
## Summary

Adds Lians to the Memory Management section as an open-source, local-first memory layer for AI agents.

The entry links to the repository and describes its bitemporal history, point-in-time recall, and MCP access without changing any other list content.

Maintainer disclosure: I am a co-founder and maintainer of Lians. Codex assisted with drafting this one-line entry and pull-request text; I reviewed both before submission.