### PR TITLE
Add DSH Studio to Coding Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/humanlayer/humanlayer?style=social" height="17" align="texttop"/> [humanlayer](https://github.com/humanlayer/humanlayer) - the best way to get AI coding agents to solve hard problems in complex codebases
 - <img src="https://img.shields.io/github/stars/ThePrimeagen/99?style=social" height="17" align="texttop"/> [99](https://github.com/ThePrimeagen/99) - neovim AI agent done right
 - <img src="https://img.shields.io/github/stars/carlrobertoh/ProxyAI?style=social" height="17" align="texttop"/> [ProxyAI](https://github.com/carlrobertoh/ProxyAI) - the leading open-source AI copilot for JetBrains
+- <img src="https://img.shields.io/github/stars/Moresyl/dsh-studio?style=social" height="17" align="texttop"/> [DSH Studio](https://github.com/Moresyl/dsh-studio) - a cross-platform desktop interface for installing, supervising, and managing DeepSeek Harness
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Adds DSH Studio to the Coding Agents section.

DSH Studio is an MIT-licensed cross-platform desktop interface for installing, supervising, and managing DeepSeek Harness on Windows, macOS, and Linux. The entry follows the existing GitHub Stars badge, source link, and one-line description format.