### PR TITLE
Add Agent QA to testing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/Giskard-AI/giskard?style=social" height="17" align="texttop"/> [giskard](https://github.com/Giskard-AI/giskard) - an open-source evaluation & testing for AI & LLM systems
 - <img src="https://img.shields.io/github/stars/Agenta-AI/agenta?style=social" height="17" align="texttop"/> [agenta](https://github.com/Agenta-AI/agenta) - an open-source LLMOps platform: prompt playground, prompt management, LLM evaluation, and LLM observability all in one place
 - <img src="https://img.shields.io/badge/NVIDIA-%25?logo=nvidia&labelColor=white" height="17" align="texttop"/> <img src="https://img.shields.io/github/stars/NVIDIA-NeMo/evaluator?style=social" height="17" align="texttop"/> [Evaluator](https://github.com/NVIDIA-NeMo/evaluator) - open-source library for scalable, reproducible evaluation of AI models and benchmarks
+- <img src="https://img.shields.io/github/stars/vostride/agent-qa?style=social" height="17" align="texttop"/> [Agent QA](https://github.com/vostride/agent-qa) - A source-available, self-improving QA agent for natural-language web and mobile tests with persistent test memory and support for local or OpenAI-compatible models.
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
## Summary

Add Agent QA to **Tools → Testing, Evaluation and Observability**.

Agent QA is a source-available, self-improving QA agent for natural-language web and mobile tests. It can use local models through OpenAI-compatible endpoints, and its persistent test memory feeds verified observations into later regression runs.

## Why it fits

- It is a testing tool powered by an LLM rather than a model provider or hosted-only service.
- Local-model support is documented alongside OpenAI-/Anthropic-compatible endpoints and Gemini.
- The list entry accurately labels the current source-available status; Agent QA uses FSL-1.1-ALv2 and converts to Apache-2.0 after two years.

## Verification

- The dynamic GitHub-stars badge and repository link use the existing entry format.
- `git diff --check` passes.
- `awesome-lint` reports no finding on the added line. The repository-wide baseline remains 387 errors and 9 warnings.

Disclosure: I am affiliated with Agent QA and Vostride.
