### PR TITLE
Add 1667 to User Interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/lobehub/lobe-chat?style=social" height="17" align="texttop"/> [Lobe Chat](https://github.com/lobehub/lobe-chat) - an open-source, modern design AI chat framework
 - <img src="https://img.shields.io/github/stars/oobabooga/text-generation-webui?style=social" height="17" align="texttop"/> [Text generation web UI](https://github.com/oobabooga/text-generation-webui) - LLM UI with advanced features, easy setup, and multiple backend support
 - <img src="https://img.shields.io/github/stars/SillyTavern/SillyTavern?style=social" height="17" align="texttop"/> [SillyTavern](https://github.com/SillyTavern/SillyTavern) - LLM Frontend for Power Users
+- <img src="https://img.shields.io/github/stars/1667-ai/1667?style=social" height="17" align="texttop"/> [1667](https://github.com/1667-ai/1667) - Terminal environment for writing fiction, keeps alternative takes in a story tree
 - <img src="https://img.shields.io/github/stars/n4ze3m/page-assist?style=social" height="17" align="texttop"/> [Page Assist](https://github.com/n4ze3m/page-assist) - Use your locally running AI models to assist you in your web browsing
 
 [Back to Table of Contents](#table-of-contents)


### PR DESCRIPTION
Adds 1667 to the User Interfaces section. I am the developer.

1667 is a terminal interface for writing fiction with a local model server. A story part can hold several alternative takes. The takes stay in a tree, and the writer selects one story line.

Local providers have first-class presets: Ollama, llama.cpp, KoboldCpp, and LM Studio. For llama.cpp and KoboldCpp, 1667 reads the exact token count from the server and supports the DRY, XTC, and dynamic temperature samplers. It also connects to OpenAI-compatible and Anthropic endpoints.

Stories and settings stay in a local project folder.

Apache 2.0. Installers for macOS, Linux, and Windows x64.

The entry follows the star-badge format used in the section.