### PR TITLE
Add open-genoffice to User Interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/oobabooga/text-generation-webui?style=social" height="17" align="texttop"/> [Text generation web UI](https://github.com/oobabooga/text-generation-webui) - LLM UI with advanced features, easy setup, and multiple backend support
 - <img src="https://img.shields.io/github/stars/SillyTavern/SillyTavern?style=social" height="17" align="texttop"/> [SillyTavern](https://github.com/SillyTavern/SillyTavern) - LLM Frontend for Power Users
 - <img src="https://img.shields.io/github/stars/n4ze3m/page-assist?style=social" height="17" align="texttop"/> [Page Assist](https://github.com/n4ze3m/page-assist) - Use your locally running AI models to assist you in your web browsing
+- <img src="https://img.shields.io/github/stars/douglas168/open-genoffice?style=social" height="17" align="texttop"/> [open-genoffice](https://github.com/douglas168/open-genoffice) - a Word/Excel/PowerPoint-compatible desktop office suite with AI editing built in, connects to any OpenAI-compatible endpoint (Ollama, LM Studio, vLLM, OpenRouter) instead of a cloud account (fork of GenOffice)
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
A Word/Excel/PowerPoint-compatible desktop office suite (fork of GenOffice, Apache-2.0) with AI editing built in. This fork removes the upstream cloud-account requirement and connects to any OpenAI-compatible endpoint — Ollama, LM Studio, vLLM, or a hosted provider like OpenRouter.