### PR TITLE
Add Otaku to User Interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/oobabooga/text-generation-webui?style=social" height="17" align="texttop"/> [Text generation web UI](https://github.com/oobabooga/text-generation-webui) - LLM UI with advanced features, easy setup, and multiple backend support
 - <img src="https://img.shields.io/github/stars/SillyTavern/SillyTavern?style=social" height="17" align="texttop"/> [SillyTavern](https://github.com/SillyTavern/SillyTavern) - LLM Frontend for Power Users
 - <img src="https://img.shields.io/github/stars/n4ze3m/page-assist?style=social" height="17" align="texttop"/> [Page Assist](https://github.com/n4ze3m/page-assist) - Use your locally running AI models to assist you in your web browsing
+- <img src="https://img.shields.io/github/stars/enclavum/otaku?style=social" height="17" align="texttop"/> [Otaku](https://github.com/enclavum/otaku) - Roleplay client for the terminal with branching stories and lore extracted as you play
 
 [Back to Table of Contents](#table-of-contents)
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/oobabooga/text-generation-webui?style=social" height="17" align="texttop"/> [Text generation web UI](https://github.com/oobabooga/text-generation-webui) - LLM UI with advanced features, easy setup, and multiple backend support
 - <img src="https://img.shields.io/github/stars/SillyTavern/SillyTavern?style=social" height="17" align="texttop"/> [SillyTavern](https://github.com/SillyTavern/SillyTavern) - LLM Frontend for Power Users
 - <img src="https://img.shields.io/github/stars/n4ze3m/page-assist?style=social" height="17" align="texttop"/> [Page Assist](https://github.com/n4ze3m/page-assist) - Use your locally running AI models to assist you in your web browsing
-- <img src="https://img.shields.io/github/stars/enclavum/otaku?style=social" height="17" align="texttop"/> [Otaku](https://github.com/enclavum/otaku) - Roleplay client for the terminal with branching stories and lore extracted as you play
+- <img src="https://img.shields.io/github/stars/enclavum/otaku?style=social" height="17" align="texttop"/> [Otaku](https://github.com/enclavum/otaku) - LLM frontend for roleplay
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Adds [Otaku](https://github.com/enclavum/otaku), a roleplay client for the terminal, to User Interfaces.

It runs against local engines — llama.cpp, KoboldCpp, Ollama, LM Studio, oMLX — with OpenRouter/NanoGPT optional; stories branch from any message, scene summaries and characters are extracted in the background while you play, and `/context` shows exactly what is sent to the model. MIT, v0.3.0 released 2026-08-17.