### PR TITLE
Add CV Evaluator to Tools > Miscellaneous

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/minitap-ai/mobile-use?style=social" height="17" align="texttop"/> [mobile-use](https://github.com/minitap-ai/mobile-use) - a powerful, open-source AI agent that controls your Android or IOS device using natural language
 - <img src="https://img.shields.io/github/stars/gabber-dev/gabber?style=social" height="17" align="texttop"/> [gabber](https://github.com/gabber-dev/gabber) - build AI applications that can see, hear, and speak using your screens, microphones, and cameras as inputs
 - <img src="https://img.shields.io/github/stars/sevenreasons/promptcat?style=social" height="17" align="texttop"/> [promptcat](https://github.com/sevenreasons/promptcat) - a zero-dependency prompt manager/catalog/library in a single HTML file
+- <img src="https://img.shields.io/github/stars/taltara/HackerAgentRank?style=social" height="17" align="texttop"/> [CV Evaluator](https://github.com/taltara/HackerAgentRank) - local-first CV scoring against explainable hiring rubrics, with the evidence behind every category score
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Adds [CV Evaluator](https://github.com/taltara/HackerAgentRank) — local-first CV scoring against explainable hiring rubrics.

**Why it fits this list:** it runs fully locally through Ollama (`gemma4:latest` by default), so a CV — about as private a document as a person has — never leaves the machine. A cloud key (Gemini / Ollama Cloud) is optional and is used for a single evaluation, never written to disk or logs. Every category score expands into the evidence from the CV that produced it, rather than returning an opaque number.

Python 3.11+ / FastAPI backend, Next.js UI, and a CLI. One command to try: `npx cv-evaluator`. MIT.

**Disclosure:** the resume-to-score core is vendored from [interviewstreet/hiring-agent](https://github.com/interviewstreet/hiring-agent) (MIT, HackerRank); this project adds multi-rubric scoring, an extensible rubric catalog, the API, the UI, and the launcher. Attribution and a per-file list of changes are in the repo's NOTICE. It is also a new project — flagging that openly so you can judge whether it is too early for the list.

Placed at the end of Tools > Miscellaneous, matching the section's existing (non-alphabetical) append order and entry format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)