### PR TITLE
Add Kolega Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/humanlayer/humanlayer?style=social" height="17" align="texttop"/> [humanlayer](https://github.com/humanlayer/humanlayer) - the best way to get AI coding agents to solve hard problems in complex codebases
 - <img src="https://img.shields.io/github/stars/ThePrimeagen/99?style=social" height="17" align="texttop"/> [99](https://github.com/ThePrimeagen/99) - neovim AI agent done right
 - <img src="https://img.shields.io/github/stars/carlrobertoh/ProxyAI?style=social" height="17" align="texttop"/> [ProxyAI](https://github.com/carlrobertoh/ProxyAI) - the leading open-source AI copilot for JetBrains
+- <img src="https://img.shields.io/github/stars/kolega-ai/kolega-code?style=social" height="17" align="texttop"/> [kolega-code](https://github.com/kolega-ai/kolega-code) - a local-first terminal coding agent where the model writes its own multi-agent workflows (Gigacode), running local models or 15+ hosted providers
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Adds Kolega Code to the Coding Agents section, at the bottom.

Kolega Code is a terminal coding agent where the model writes its own multi-agent workflows (Gigacode). It is local-first: all session state stays on disk, and it works with local models as well as 15+ hosted providers. MCP server support is built in. Journaled sessions resume from cached results, so unchanged calls are not repeated.
