### PR TITLE
Add Persona — local-first workspace with Ollama-powered AI chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 
 [Back to Table of Contents](#table-of-contents)
 
+- [Persona](https://github.com/jayamitkatariya/personacli) - Local-first personal workspace: notes, tasks, and AI chat over plain Markdown files. Connects to Ollama for free private AI.
 ## Large Language Models
 
 ### Explorers, Benchmarks, Leaderboards


### PR DESCRIPTION
Add [Persona](https://github.com/jayamitkatariya/personacli) — a local-first personal workspace where notes, tasks and an AI chat live as plain Markdown files. Auto-detects running Ollama so the AI is free and fully on-device. MIT licensed.