### PR TITLE
Add qwen3.8-27b-in-c to inference engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/brontoguana/krasis?style=social" height="17" align="texttop"/> [krasis](https://github.com/brontoguana/krasis) - a Hybrid LLM runtime which focuses on efficient running of larger models on consumer grade VRAM limited hardware
 - <img src="https://img.shields.io/github/stars/nlzy/vllm-gfx906?style=social" height="17" align="texttop"/> [vllm-gfx906](https://github.com/nlzy/vllm-gfx906) - vLLM for AMD gfx906 GPUs, e.g. Radeon VII / MI50 / MI60
 - <img src="https://img.shields.io/github/stars/intel/llm-scaler?style=social" height="17" align="texttop"/> [llm-scaler](https://github.com/intel/llm-scaler) - run LLMs on Intel Arc™ Pro B60 GPUs
+- <img src="https://img.shields.io/github/stars/shyringo/qwen3.8-27b-in-c?style=social" height="17" align="texttop"/> [qwen3.8-27b-in-c](https://github.com/shyringo/qwen3.8-27b-in-c) - native C inference for Qwen3.8-27B on a single laptop CPU, with an 8 GB tested path and no GPU or Python
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
## Summary

Add [qwen3.8-27b-in-c](https://github.com/shyringo/qwen3.8-27b-in-c) to the Inference engines list.

## Why it fits

It is an Apache-2.0 native C runtime for Qwen3.8-27B on a single laptop CPU. It directly loads GGUF weights, needs no GPU or Python, has a tested 8 GB RAM path, and reaches up to 2.52 token/s on the documented 32 GB x86 laptop. Its resident OpenAI-compatible API supports function tools, parallel calls, tool-result replay, and SSE.

## Validation

- Verified the project is locally executable and open source
- Checked the current list for a duplicate entry
- Kept the change to one README line in the existing format

Disclosure: I maintain the project being added.