### PR TITLE
Add STACKELIER to miscellaneous tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - [Hunyuan3D](https://huggingface.co/collections/tencent/hunyuan3d) - a collection of everything related (models, datasets etc.) to 3D assets generation from Tencent
 - [Hunyuan-GameCraft-1.0](https://huggingface.co/tencent/Hunyuan-GameCraft-1.0) - a novel framework for high-dynamic interactive video generation in game environments
 - [void-model](https://huggingface.co/netflix/void-model) - a model from Netflix that removes objects from videos along with all interactions they induce on the scene — not just secondary effects like shadows and reflections, but physical interactions like objects falling when a person is removed
+- - [STACKELIER](https://stackelier.com/) - evidence-based private AI stack finder that matches professional use cases, privacy constraints and hardware to verified local/self-hosted configurations
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Adds STACKELIER, an evidence-based decision resource for selecting private/local AI configurations based on use case, privacy constraints and hardware.

STACKELIER itself is a web-based discovery tool; it does not perform local inference. The suggested placement is in the Miscellaneous tools section because it helps users choose verified local/self-hosted AI configurations rather than providing an inference runtime itself.