### PR TITLE
Add Solair AI to Inference platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 ## Inference platforms
 
 - [LM Studio](https://lmstudio.ai/) - discover, download and run local LLMs
+- [Solair AI](https://solairai.app) - free on-device ChatGPT-style app for iPhone, iPad, Mac, and Watch
 - <img src="https://img.shields.io/github/stars/unslothai/unsloth?style=social" height="17" align="texttop"/> [unsloth](https://github.com/unslothai/unsloth) -  unified web UI for training and running open models like Qwen, DeepSeek, and Gemma locally
 - <img src="https://img.shields.io/github/stars/mudler/LocalAI?style=social" height="17" align="texttop"/> [LocalAI](https://github.com/mudler/LocalAI) -  the free, open-source alternative to OpenAI, Claude and others
 - <img src="https://img.shields.io/github/stars/menloresearch/jan?style=social" height="17" align="texttop"/> [jan](https://github.com/menloresearch/jan) - an open source alternative to ChatGPT that runs 100% offline on your computer


### PR DESCRIPTION
Add Solair AI, a native Apple on-device LLM app (MLX). Same style as the LM Studio website entry. No GitHub stars badge because there is no public repo.

https://solairai.app