### PR TITLE
Add ai-media-studio to Tools > Miscellaneous

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/minitap-ai/mobile-use?style=social" height="17" align="texttop"/> [mobile-use](https://github.com/minitap-ai/mobile-use) - a powerful, open-source AI agent that controls your Android or IOS device using natural language
 - <img src="https://img.shields.io/github/stars/gabber-dev/gabber?style=social" height="17" align="texttop"/> [gabber](https://github.com/gabber-dev/gabber) - build AI applications that can see, hear, and speak using your screens, microphones, and cameras as inputs
 - <img src="https://img.shields.io/github/stars/sevenreasons/promptcat?style=social" height="17" align="texttop"/> [promptcat](https://github.com/sevenreasons/promptcat) - a zero-dependency prompt manager/catalog/library in a single HTML file
+- <img src="https://img.shields.io/github/stars/HARSH-THAKAR/ai-media-studio?style=social" height="17" align="texttop"/> [ai-media-studio](https://github.com/HARSH-THAKAR/ai-media-studio) - fully local topic-to-video pipeline: script and scene planning, narration, per-scene images, word-by-word subtitles and render, no paid APIs
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Adds [ai-media-studio](https://github.com/HARSH-THAKAR/ai-media-studio) under **Tools > Miscellaneous**, following the existing star-badge format.

It is a fully local short-form video pipeline: a local LLM (tested on `llama3.1:8b` via Ollama) writes the script and plans scenes, ComfyUI generates an image per scene, Kokoro narrates, and FFmpeg renders a subtitled vertical MP4. No API keys, no cloud, one command.

The part most relevant to this list is what it took to make a small local model write to a target length, which is measured and documented in the README — a word budget for the whole script missed by a median of 36%, while the same budget expressed per scene missed by 18% and missed consistently, so the bias can be cancelled. The finished narration is then measured and the script rewritten at the rate the voice actually demonstrated.

MIT licensed, tests run in CI on Linux and Windows, demo videos in the README.