### PR TITLE
Add XTLLM to inference engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/FastFlowLM/FastFlowLM?style=social" height="17" align="texttop"/> [FastFlowLM](https://github.com/FastFlowLM/FastFlowLM) - run LLMs on AMD Ryzen™ AI NPUs
 - <img src="https://img.shields.io/github/stars/lightseekorg/tokenspeed?style=social" height="17" align="texttop"/> [tokenspeed](https://github.com/lightseekorg/tokenspeed) - a speed-of-light LLM inference engine
 - <img src="https://img.shields.io/github/stars/brontoguana/krasis?style=social" height="17" align="texttop"/> [krasis](https://github.com/brontoguana/krasis) - a Hybrid LLM runtime which focuses on efficient running of larger models on consumer grade VRAM limited hardware
+- <img src="https://img.shields.io/github/stars/opktunme/XTLLM?style=social" height="17" align="texttop"/> [XTLLM](https://github.com/opktunme/XTLLM) - experimental Windows Vulkan inference for selected large MoE models on AMD GPUs, with VRAM/RAM/NVMe expert tiering; validated on Radeon RX 6700 XT
 - <img src="https://img.shields.io/github/stars/nlzy/vllm-gfx906?style=social" height="17" align="texttop"/> [vllm-gfx906](https://github.com/nlzy/vllm-gfx906) - vLLM for AMD gfx906 GPUs, e.g. Radeon VII / MI50 / MI60
 - <img src="https://img.shields.io/github/stars/intel/llm-scaler?style=social" height="17" align="texttop"/> [llm-scaler](https://github.com/intel/llm-scaler) - run LLMs on Intel Arc™ Pro B60 GPUs
 


### PR DESCRIPTION
Adds [XTLLM](https://github.com/opktunme/XTLLM) to **Inference engines** for readers exploring local MoE inference on consumer AMD GPUs with limited VRAM. The entry follows the existing link and star-badge format.

XTLLM is an experimental, text-only Windows Vulkan engine for selected model backends. It tiers experts across VRAM, budgeted system RAM, and NVMe; the RX 6700 XT is currently the only hardware-validated card. The description keeps these limits explicit and makes no claims of general model compatibility or unverified performance.

Validation: checked the project's current README, confirmed no existing XTLLM entry or issue/PR in this directory, and ran `git diff --check`.

Disclosure: submitted on behalf of XTLLM's maintainer with AI assistance.
