### PR TITLE
Add bean to Tools/Models

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 ### Models
 
 - <img src="https://img.shields.io/github/stars/AlexsJones/llmfit?style=social" height="17" align="texttop"/> [llmfit](https://github.com/AlexsJones/llmfit) - hundreds of models & providers, one command to find what runs on your hardware
+- <img src="https://img.shields.io/github/stars/heenatrivedi321-max/bean?style=social" height="17" align="texttop"/> [bean](https://github.com/heenatrivedi321-max/bean) - one command to pick, download, and hand off the right local model for your hardware to Ollama
 - <img src="https://img.shields.io/github/stars/dottxt-ai/outlines?style=social" height="17" align="texttop"/> [outlines](https://github.com/dottxt-ai/outlines) - structured outputs for LLMs
 - <img src="https://img.shields.io/github/stars/mostlygeek/llama-swap?style=social" height="17" align="texttop"/> [llama-swap](https://github.com/mostlygeek/llama-swap) - reliable model swapping for any local OpenAI compatible server - llama.cpp, vllm, etc.
 - <img src="https://img.shields.io/github/stars/guidance-ai/llguidance?style=social" height="17" align="texttop"/> [llguidance](https://github.com/guidance-ai/llguidance) - super-fast structured outputs


### PR DESCRIPTION
Adds [bean](https://github.com/heenatrivedi321-max/bean) next to llmfit in Tools/Models, since it solves the same core problem.

bean checks your free RAM, picks the biggest quant that actually fits with headroom, downloads it, and hands off to the Ollama app -- one command, no config.

Open source (MIT), cross-platform (macOS/Linux/Windows), actively maintained with CI.