### PR TITLE
Add PowerPC/POWER8 llama.cpp ports (Inference engines)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/brontoguana/krasis?style=social" height="17" align="texttop"/> [krasis](https://github.com/brontoguana/krasis) - a Hybrid LLM runtime which focuses on efficient running of larger models on consumer grade VRAM limited hardware
 - <img src="https://img.shields.io/github/stars/nlzy/vllm-gfx906?style=social" height="17" align="texttop"/> [vllm-gfx906](https://github.com/nlzy/vllm-gfx906) - vLLM for AMD gfx906 GPUs, e.g. Radeon VII / MI50 / MI60
 - <img src="https://img.shields.io/github/stars/intel/llm-scaler?style=social" height="17" align="texttop"/> [llm-scaler](https://github.com/intel/llm-scaler) - run LLMs on Intel Arc™ Pro B60 GPUs
+- <img src="https://img.shields.io/github/stars/Scottcjn/llama-cpp-power8?style=social" height="17" align="texttop"/> [llama-cpp-power8](https://github.com/Scottcjn/llama-cpp-power8) - llama.cpp optimized for IBM POWER8 (ppc64le) with vec_perm collapse and DCBT prefetch
+- <img src="https://img.shields.io/github/stars/Scottcjn/llama-cpp-tigerleopard?style=social" height="17" align="texttop"/> [llama-cpp-tigerleopard](https://github.com/Scottcjn/llama-cpp-tigerleopard) - llama.cpp for Mac OS X Tiger & Leopard on PowerPC G4/G5
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
### What this adds

Two llama.cpp inference-engine ports for architectures the mainstream builds don't target, under **Inference engines** (alongside existing hardware-specific forks like `ik_llama.cpp` and `vllm-gfx906`):

- **llama-cpp-power8** — llama.cpp optimized for IBM POWER8 / ppc64le (vec_perm collapse, DCBT prefetch). ~8.8x stock on refurbished enterprise POWER8.
- **llama-cpp-tigerleopard** — llama.cpp built for Mac OS X Tiger & Leopard on PowerPC G4/G5.

### Why it's valuable

The list covers modern CPU/GPU/NPU targets well; these fill the "sovereign inference on non-x86 / vintage hardware" gap. Both are open source and actively maintained.

### Affiliation disclosure

I'm the author (Elyan Labs / @Scottcjn). Happy to trim to a single entry or move to the Hardware section if you'd prefer.
