### PR TITLE
Add Ferrum to inference engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/brontoguana/krasis?style=social" height="17" align="texttop"/> [krasis](https://github.com/brontoguana/krasis) - a Hybrid LLM runtime which focuses on efficient running of larger models on consumer grade VRAM limited hardware
 - <img src="https://img.shields.io/github/stars/nlzy/vllm-gfx906?style=social" height="17" align="texttop"/> [vllm-gfx906](https://github.com/nlzy/vllm-gfx906) - vLLM for AMD gfx906 GPUs, e.g. Radeon VII / MI50 / MI60
 - <img src="https://img.shields.io/github/stars/intel/llm-scaler?style=social" height="17" align="texttop"/> [llm-scaler](https://github.com/intel/llm-scaler) - run LLMs on Intel Arc™ Pro B60 GPUs
+- <img src="https://img.shields.io/github/stars/sizzlecar/ferrum-infer-rs?style=social" height="17" align="texttop"/> [Ferrum](https://github.com/sizzlecar/ferrum-infer-rs) - Rust-native local LLM inference with a CLI, an OpenAI-compatible API, and Metal/CUDA backends
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Adds Ferrum to **Inference engines** in the existing one-line format.

Ferrum is an open-source Rust runtime for local inference through `ferrum run` and an OpenAI-compatible HTTP API. The description reflects the published [v0.8.8 release](https://github.com/sizzlecar/ferrum-infer-rs/releases/tag/v0.8.8), with Apple Silicon Metal and Linux NVIDIA CUDA support.

Checked the contribution guide, existing entries and all-state issues/PRs for duplicates; `git diff --check` passes and the project link resolves.

Disclosure: I maintain Ferrum. This submission was prepared with AI assistance.
