### PR TITLE
Add ipsupport-code to Coding Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/humanlayer/humanlayer?style=social" height="17" align="texttop"/> [humanlayer](https://github.com/humanlayer/humanlayer) - the best way to get AI coding agents to solve hard problems in complex codebases
 - <img src="https://img.shields.io/github/stars/ThePrimeagen/99?style=social" height="17" align="texttop"/> [99](https://github.com/ThePrimeagen/99) - neovim AI agent done right
 - <img src="https://img.shields.io/github/stars/carlrobertoh/ProxyAI?style=social" height="17" align="texttop"/> [ProxyAI](https://github.com/carlrobertoh/ProxyAI) - the leading open-source AI copilot for JetBrains
+- <img src="https://img.shields.io/github/stars/ipsupport-llc/ipsupport-code?style=social" height="17" align="texttop"/> [ipsupport-code](https://github.com/ipsupport-llc/ipsupport-code) - a self-learning local coding agent for LM Studio, single static Go binary with opt-in OS-level sandboxing
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Adds [ipsupport-code](https://github.com/ipsupport-llc/ipsupport-code) to Tools → Coding Agents.

A self-learning local coding agent for LM Studio and other OpenAI-compatible endpoints: single static Go binary, plan/auto modes, permissions, opt-in OS-level sandboxing (Seatbelt/Landlock) for its shell tool. MIT license.