### PR TITLE
Add OrcaReplay to Tools → Model Context Protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - <img src="https://img.shields.io/github/stars/awslabs/mcp?style=social" height="17" align="texttop"/> [awslabs/mcp](https://github.com/awslabs/mcp) - AWS MCP Servers — helping you get the most out of AWS, wherever you use MCP
 - <img src="https://img.shields.io/github/stars/sooperset/mcp-atlassian?style=social" height="17" align="texttop"/> [mcp-atlassian](https://github.com/sooperset/mcp-atlassian) - MCP server for Atlassian tools (Confluence, Jira)
 - <img src="https://img.shields.io/github/stars/bytebase/dbhub?style=social" height="17" align="texttop"/> [dbhub](https://github.com/bytebase/dbhub) - zero-dependency, token-efficient database MCP server for Postgres, MySQL, SQL Server, MariaDB, SQLite
+- <img src="https://img.shields.io/github/stars/Continuum-AI-Corp/OrcaReplay?style=social" height="17" align="texttop"/> [OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) - MCP server over recorded coding-agent runs: records an agent against any OpenAI-compatible endpoint, including a local one, and replays the run with the model server switched off.
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Adds OrcaReplay to **Tools → Model Context Protocol**, in the section's existing badge-and-link format.

**Disclosure: I work on it.** Apache-2.0, no paid tier, nothing hosted.

## Why it belongs on a *local* LLM list

Two reasons, and I checked both today rather than assuming:

**1. It records against a local endpoint.** The origin is just a base URL, so it works the same against Ollama, llama.cpp or vLLM as against a vendor. Verified end to end against Ollama running `qwen3.5:0.8b`:

```console
$ orca record generic-openai -- node call.mjs
local model said: "PRIVATE"
info recorded run=run_6352c272d068 events=6 exit=0
```

**2. Replay needs no model at all** — which is about as local as it gets:

```console
$ taskkill /F /IM ollama.exe            # the model server is now gone
$ curl -m 3 http://localhost:11434/v1/models    # nothing listening

$ orca replay last
local model said: "PRIVATE"
info replay.done reused=1/1 exact=1 divergences=0 unmatched=0 exit=0
```

The program ran again and got its answer with no model server anywhere on the machine.

Traces are files under `.orca/` in the project. There is no account, no telemetry and no upload path in the code — relevant to this list's readers, and the reason I am not describing it as "cloud-optional".

## The MCP part

It ships an MCP server that exposes recorded runs — timeline, model exchanges, tool calls, diffs — so an agent can query what happened in an earlier session. It is in the official MCP Registry as `io.github.Continuum-AI-Corp/orcareplay`. If you would rather it sat under **Tools → Agent Frameworks** than under Model Context Protocol, move it; the MCP server is one surface rather than the whole thing.

## One scope note

`egress=blocked` on replay means **model-provider** egress. Replay still executes recorded tool calls for real, so a recorded `curl` reaches the network. It is not a sandbox, and the README says so — worth being exact about on a list whose readers pick local tooling for that kind of reason.

Entry uses the same `img.shields.io/github/stars/...?style=social` badge shape as the rest of the section. Happy to shorten the description.
