### PR TITLE
Add loudr-1 to the Audio models

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ A curated list of awesome platforms, tools, practices and resources that helps r
 - [VibeVoice](https://huggingface.co/collections/microsoft/vibevoice-68a2ef24a875c44be47b034f) - a collection of frontier text-to-speech models from Microsoft
 - [Kitten TTS](https://huggingface.co/KittenML/models) - a collection of open-source realistic text-to-speech models designed for lightweight deployment and high-quality voice synthesis
 - <img src="https://img.shields.io/badge/NVIDIA-%25?logo=nvidia&labelColor=white" height="17" align="texttop"/> [Streaming Sortformer Diarizer 4spk v2.1](https://huggingface.co/nvidia/diar_streaming_sortformer_4spk-v2.1) - a streaming version of a novel end-to-end neural model for speaker diarization from NVIDIA
+- [loudr-1](https://huggingface.co/loudreader/loudr-1) - on-device text-to-speech with 28 voices in 10 languages and voice cloning, plus a faster loudr-1-turbo variant, run by the open-source loudkit engine with native Python, Swift, Go, Rust and TypeScript SDKs
 
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Adds loudr-1 to Specific models → Audio.

loudr-1 is an on-device text-to-speech model (Apache-2.0, derived from Resemble AI's Chatterbox) with 28 voices in 10 languages and voice cloning from about ten seconds of audio. A faster variant, loudr-1-turbo, predicts two speech tokens per step. Both run locally through the open-source loudkit engine, which has native Python, Swift, Go, Rust and TypeScript SDKs and a local OpenAI-compatible speech endpoint.

* Model: https://huggingface.co/loudreader/loudr-1 (turbo: https://huggingface.co/loudreader/loudr-1-turbo)
* Engine: https://github.com/loudreader/loudkit
* Voice samples: https://loudreader.github.io/loudkit/demo/

Disclosure: I maintain loudkit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
